### PR TITLE
Codex workflowの差分なし失敗を解消

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -213,15 +213,18 @@ jobs:
         run: cargo fmt --check
 
       - name: Check meaningful changes
+        id: meaningful_changes
         run: |
-          if git diff --name-only | grep -v ".codex" | grep -q .; then
-            echo "Valid changes"
-          else
+          if git diff --quiet -- . ':(exclude).codex'; then
             echo "No meaningful changes"
-            exit 1
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Valid changes"
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Require implementation file changes
+        if: steps.meaningful_changes.outputs.has_changes == 'true'
         run: |
           if [ "${{ steps.issue_type.outputs.requires_src_tests }}" = "true" ]; then
             if git diff --name-only | grep -qE '^(src/|tests/)'; then


### PR DESCRIPTION
## 概要

- Codex Issue Automation が .codex 以外の差分なしで失敗する挙動を修正
- 差分なしの場合は PR を作らず workflow を成功終了できるように変更
- Issue #24 に関連

## 作業内容

- Check meaningful changes を失敗ステップから出力判定ステップへ変更
- .codex 除外を grep ではなく git pathspec の exclude に統一
- 実装ファイル要求チェックは意味のある差分がある場合だけ実行するように変更

## 作業意図

- Codex が .codex/prompt.md のみ変更、または既存対応済みで追加差分がない場合に workflow 全体が失敗する問題を避けるため
- 実装 issue で src/tests 以外だけ変更された場合の検出は維持するため

## 手動で次にするべき作業

- GitHub Actions の quality-gate が成功していることを確認
- 問題なければレビュー後に main へマージ

## 変更ファイル

- .github/workflows/codex.yml

## テスト結果

- cargo fmt --check: 成功
- cargo clippy --all-targets --all-features -- -D warnings: 成功
- cargo test: 成功

## 制限事項

- Codex Issue Automation の issue ラベル実行は PR 上では直接再現していない
- workflow ファイルのみの修正