### PR TITLE
Discord Gatewayを廃止してWebhook運用へ移行

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -14,7 +14,7 @@ jobs:
   codex:
     if: github.event_name == 'issues' && github.event.label.name == 'codex'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 45
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
@@ -34,9 +34,12 @@ jobs:
 
       - name: Classify issue
         id: issue_type
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
-          issue_title=$(printf '%s\n' "${{ github.event.issue.title }}")
-          issue_body=$(printf '%s\n' "${{ github.event.issue.body }}")
+          issue_title=$ISSUE_TITLE
+          issue_body=$ISSUE_BODY
 
           issue_kind="generic"
 
@@ -61,10 +64,15 @@ jobs:
           echo "kind=$issue_kind" >> "$GITHUB_OUTPUT"
 
       - name: Prepare prompt
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_KIND: ${{ steps.issue_type.outputs.kind }}
         run: |
           mkdir -p .codex
 
-          cat > .codex/prompt.md << 'EOF'
+          {
+          cat << 'EOF'
           You are implementing a GitHub issue for this repository.
 
           Before making changes, read:
@@ -75,17 +83,24 @@ jobs:
           - docs/ai/DECISIONS.md
 
           Issue title:
-          ${{ github.event.issue.title }}
+          EOF
+          printf '%s\n' "$ISSUE_TITLE"
+          cat << 'EOF'
 
           Issue body:
-          ${{ github.event.issue.body }}
+          EOF
+          printf '%s\n' "$ISSUE_BODY"
+          cat << 'EOF'
 
           Detected issue kind:
-          ${{ steps.issue_type.outputs.kind }}
+          EOF
+          printf '%s\n' "$ISSUE_KIND"
+          cat << 'EOF'
 
           Rules:
           - Follow AGENTS.md
           - If the issue explicitly allows scope overrides, follow the issue scope
+          - If the issue explicitly defines a broad implementation, do not stop solely because the work is large
           - Do not touch workflows, deploy, infra, or secrets unless the issue explicitly allows it
           - Write PR title and body in Japanese
           - Run cargo fmt --check, cargo clippy --all-targets --all-features -- -D warnings, cargo test when possible
@@ -93,6 +108,7 @@ jobs:
           - Stop if approval is required
           - Keep changes focused on the issue only
           EOF
+          } > .codex/prompt.md
 
       - name: Run Codex
         id: codex
@@ -105,6 +121,14 @@ jobs:
 
       - name: Restore generated Codex prompt
         run: git checkout -- .codex/prompt.md
+
+      - name: Verify repository changes
+        run: |
+          changed_files=$(git diff --name-only -- . ':(exclude).codex')
+          if [ -z "$changed_files" ]; then
+            echo "::error::Codex did not create repository changes. Check the Run Codex log for blockers, scope-limit decisions, or approval requests."
+            exit 1
+          fi
 
       - name: Install Rust components
         continue-on-error: true
@@ -129,8 +153,10 @@ jobs:
 
       - name: Build Pull Request metadata
         id: pr_metadata
+        env:
+          ISSUE_TITLE: ${{ github.event.issue.title }}
         run: |
-          issue_title=$(printf '%s\n' "${{ github.event.issue.title }}")
+          issue_title=$ISSUE_TITLE
           safe_title=$(printf '%s\n' "$issue_title" | sed -E 's/^\[[^]]+\][[:space:]]*//')
           if [ -z "$safe_title" ]; then
             safe_title="Issue #${{ github.event.issue.number }} の対応"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,11 +9,13 @@ This repository uses Codex to automate:
 3. Draft PR creation
 4. Human review and merge
 
-Codex must prioritize safety, small changes, low token usage, and minimal blast radius.
+Codex must prioritize safety, focused changes, and minimal blast radius. Small changes are preferred, but Codex may
+complete larger implementation issues when the issue explicitly defines the broad scope and allowed paths.
 
 <!--
 このリポジトリでは Codex を使って Issue → 実装 → Draft PR 作成までを自動化する。
-安全性・小さな差分・低トークン消費・限定的な変更範囲を最優先とする。
+安全性・焦点の合った差分・限定的な変更範囲を最優先とする。
+Issue が広い scope と変更許可パスを明示している場合は、大きめの実装も完了まで進めてよい。
 -->
 
 ---
@@ -128,7 +130,7 @@ Codex should prefer:
 * Small refactors
 * Small CI improvements
 
-Codex should avoid:
+Codex should avoid unless the issue explicitly requires a larger implementation:
 
 * Large architectural changes
 * Multi-directory refactors
@@ -139,7 +141,7 @@ Codex should avoid:
 
 <!--
 小規模修正・ログ改善・テスト追加・README 修正などを優先する。
-大規模設計変更や複数機能をまとめた PR は避ける。
+Issue で明示されていない大規模設計変更や複数機能をまとめた PR は避ける。
 -->
 
 ---
@@ -192,26 +194,25 @@ disown
 破壊的コマンド、権限昇格、バックグラウンド実行は禁止。
 -->
 
-<!--
+## PR Size Guidance
 
----
+Codex should keep changes as small as the issue reasonably allows.
 
-## PR Size Limits
-
-Codex must keep changes small.
-
-Maximum allowed limits:
+The following are review guidance targets, not hard stop conditions:
 
 ```yaml id="u2k8cd"
-max_changed_files: 10
-max_added_lines: 300
-max_deleted_lines: 150
+preferred_max_changed_files: 10
+preferred_max_added_lines: 300
+preferred_max_deleted_lines: 150
 ```
 
-If a task exceeds these limits, Codex should stop and request the work be split into smaller issues.
+If an issue explicitly asks for a broad implementation and lists the allowed paths, Codex may exceed these targets.
+When exceeding them, Codex must keep the work focused on the issue, avoid unrelated refactors, and explain the larger
+scope in the PR limitations or work-intent section.
 
-変更ファイル数・追加行数・削除行数が多すぎる場合は停止し、Issue を分割すること。
-
+<!--
+変更ファイル数・追加行数・削除行数の目安は review しやすくするための推奨値であり、停止条件ではない。
+Issue が広い実装と変更許可パスを明示している場合は、目安を超えてもよい。
 -->
 
 ---
@@ -316,14 +317,14 @@ main への直接 push・自動 merge・force push は禁止。
 
 Codex should stop work if:
 
-* More than 15 minutes have elapsed
-* More than 10 files would be changed
-* More than 300 lines would be added
+* The workflow time budget is close to expiring and no coherent implementation can be completed
 * The scope becomes unclear
 * Human approval is required
+* The required implementation would touch forbidden paths that the issue did not explicitly approve
 
 <!--
-時間超過・差分超過・不明確な要件・人間承認が必要な場合は停止する。
+時間切れが近い場合、不明確な要件、人間承認が必要な場合、または未承認の禁止パス変更が必要な場合は停止する。
+差分量だけを理由に停止しない。
 -->
 
 ---

--- a/docs/ai/ARCHITECTURE.md
+++ b/docs/ai/ARCHITECTURE.md
@@ -279,7 +279,7 @@ All PRs should:
 * Reference the related issue
 * Include changed files
 * Include test results
-* Stay under 300 lines if possible
+* Stay under 300 lines when the issue scope reasonably allows it
 * Stay within the allowed paths
 * Avoid touching unrelated code
 
@@ -296,11 +296,18 @@ Issue 番号、変更内容、テスト結果を含める。
 Codex must immediately stop if:
 
 * A forbidden path would be modified
-* More than 10 files would change
-* More than 300 lines would be added
 * The issue scope becomes unclear
 * Human approval is required
 
+Codex should treat these as review guidance targets, not hard stop conditions:
+
+* 10 changed files
+* 300 added lines
+
+If the issue explicitly defines a broad implementation and allowed paths, Codex may exceed these targets while keeping
+the implementation focused on that issue.
+
 <!--
-差分が大きすぎる場合、不明確な要件がある場合、承認が必要な場合は停止する。
+禁止パス変更、不明確な要件、承認が必要な場合は停止する。
+差分量は停止条件ではなく review 目安として扱う。
 -->

--- a/src/handler/interaction.rs
+++ b/src/handler/interaction.rs
@@ -1,6 +1,7 @@
 use crate::models::common::Data;
 use crate::reminder::service::parse_stop_button_custom_id;
 use crate::reminder::ui::{self, ReminderUiAction};
+use crate::usecase::birth_reset_usecase::parse_webhook_reset_button_custom_id;
 use serenity::all::{
     ComponentInteraction, ComponentInteractionDataKind, CreateInteractionResponse,
     CreateInteractionResponseMessage, EditInteractionResponse,
@@ -12,6 +13,12 @@ pub async fn handle_component_interaction(
 ) -> anyhow::Result<bool> {
     if let Some(action) = ui::parse_reminder_ui_custom_id(&component.data.custom_id) {
         return handle_reminder_ui_interaction(data, component, action).await;
+    }
+
+    if let Some((guild_id, member_id)) =
+        parse_webhook_reset_button_custom_id(&component.data.custom_id)
+    {
+        return handle_birth_reset_interaction(data, component, guild_id, member_id).await;
     }
 
     let Some((guild_id, member_id)) = parse_stop_button_custom_id(&component.data.custom_id) else {
@@ -86,6 +93,43 @@ pub async fn handle_component_interaction(
         )
         .await?;
 
+    Ok(true)
+}
+
+async fn handle_birth_reset_interaction(
+    data: &Data,
+    component: &ComponentInteraction,
+    guild_id: i64,
+    member_id: i64,
+) -> anyhow::Result<bool> {
+    if i64::from(component.user.id) != member_id {
+        component
+            .create_response(
+                &data.discord_http,
+                CreateInteractionResponse::Message(
+                    CreateInteractionResponseMessage::new()
+                        .content("この操作は自分のみ使えるのだ")
+                        .ephemeral(true),
+                ),
+            )
+            .await?;
+        return Ok(true);
+    }
+
+    data.birth_reset_usecase
+        .reset_member_birth(guild_id, member_id)
+        .await?;
+
+    component
+        .create_response(
+            &data.discord_http,
+            CreateInteractionResponse::UpdateMessage(
+                CreateInteractionResponseMessage::new()
+                    .content("誕生日の通知登録を解除したのだ。")
+                    .components(Vec::new()),
+            ),
+        )
+        .await?;
     Ok(true)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,15 +125,9 @@ async fn main() -> anyhow::Result<()> {
                 let birth_notify_usecase = BirthNotifyUsecase::new(pool.clone(), ctx.http.clone())?;
                 let guild_update_usecase = GuildUpdateUsecase::new(pool.clone(), ctx.http.clone())?;
                 let reminder_service = ReminderService::new(pool.clone(), ctx.http.clone())?;
-                let reminder_scan_service = ReminderService::new(pool.clone(), ctx.http.clone())?;
                 guild_update_usecase.invoke().await?;
 
                 tokio::spawn(AnnualBirthdayNotifier::run(birth_notify_usecase));
-                tokio::spawn(async move {
-                    if let Err(e) = run_healthcheck_server(reminder_scan_service).await {
-                        tracing::error!("Healthcheck server stopped: {}", e);
-                    }
-                });
 
                 poise::builtins::register_globally(ctx, &framework.options().commands).await?;
 
@@ -145,6 +139,12 @@ async fn main() -> anyhow::Result<()> {
                     reminder_service,
                     discord_http: ctx.http.clone(),
                 };
+                let healthcheck_data = data.clone();
+                tokio::spawn(async move {
+                    if let Err(e) = run_healthcheck_server(healthcheck_data).await {
+                        tracing::error!("Healthcheck server stopped: {}", e);
+                    }
+                });
                 Ok(data)
             })
         })

--- a/src/models/common.rs
+++ b/src/models/common.rs
@@ -6,6 +6,7 @@ use crate::usecase::guild_update_usecase::GuildUpdateUsecase;
 use serenity::all::Http;
 use std::sync::Arc;
 
+#[derive(Clone)]
 pub struct Data {
     pub birth_list_usecase: BirthListUsecase,
     pub birth_signup_usecase: BirthSignupUsecase,

--- a/src/services/healthcheck.rs
+++ b/src/services/healthcheck.rs
@@ -1,6 +1,6 @@
-use crate::reminder::service::ReminderService;
+use crate::models::common::Data;
+use crate::services::interaction_webhook::{handle_interaction_body, WebhookHttpResponse};
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
-use serde::Deserialize;
 use std::env;
 use std::str;
 
@@ -10,10 +10,10 @@ use tokio::net::{TcpListener, TcpStream};
 const DISCORD_PUBLIC_KEY_ENV: &str = "DISCORD_PUBLIC_KEY";
 const MAX_REQUEST_BYTES: usize = 64 * 1024;
 
-pub async fn run_healthcheck_server(reminder_service: ReminderService) -> anyhow::Result<()> {
+pub async fn run_healthcheck_server(data: Data) -> anyhow::Result<()> {
     let port = env::var("PORT").unwrap_or_else(|_| "8080".to_string());
     let port: u16 = port.parse()?;
-    run_healthcheck_server_on(port, Some(reminder_service)).await
+    run_healthcheck_server_on(port, Some(data)).await
 }
 
 pub async fn run_passive_healthcheck_server() -> anyhow::Result<()> {
@@ -22,16 +22,13 @@ pub async fn run_passive_healthcheck_server() -> anyhow::Result<()> {
     run_healthcheck_server_on(port, None).await
 }
 
-pub async fn run_healthcheck_server_on(
-    port: u16,
-    reminder_service: Option<ReminderService>,
-) -> anyhow::Result<()> {
+pub async fn run_healthcheck_server_on(port: u16, data: Option<Data>) -> anyhow::Result<()> {
     let listener = TcpListener::bind(format!("0.0.0.0:{port}")).await?;
     tracing::info!("Healthcheck server listening on 0.0.0.0:{}", port);
 
     loop {
         let (mut stream, _) = listener.accept().await?;
-        let reminder_service = reminder_service.clone();
+        let data = data.clone();
 
         tokio::spawn(async move {
             let request = match read_http_request(&mut stream).await {
@@ -45,7 +42,7 @@ pub async fn run_healthcheck_server_on(
 
             let request_head = request_head_for_log(&request);
             tracing::debug!(%request_head, "received healthcheck request");
-            let response = handle_request(&request, reminder_service.as_ref()).await;
+            let response = handle_request(&request, data.as_ref()).await;
             tracing::debug!(?response, "healthcheck response");
 
             if let Err(e) = stream.write_all(response.as_bytes()).await {
@@ -81,7 +78,7 @@ async fn read_http_request(stream: &mut TcpStream) -> anyhow::Result<Option<Vec<
 
         request.extend_from_slice(&buffer[..read_size]);
         if request.len() > MAX_REQUEST_BYTES {
-            anyhow::bail!("request exceeded {} bytes", MAX_REQUEST_BYTES);
+            anyhow::bail!("request exceeded {MAX_REQUEST_BYTES} bytes");
         }
 
         if request_is_complete(&request) {
@@ -90,20 +87,20 @@ async fn read_http_request(stream: &mut TcpStream) -> anyhow::Result<Option<Vec<
     }
 }
 
-async fn handle_request(request: &[u8], reminder_service: Option<&ReminderService>) -> String {
+async fn handle_request(request: &[u8], data: Option<&Data>) -> String {
     let Some(request) = HttpRequest::parse(request) else {
         return json_response(400, r#"{"error":"bad request"}"#);
     };
 
     if request.method == "POST" && request.path == "/interactions" {
-        return handle_discord_interaction(&request);
+        return handle_discord_interaction(&request, data).await;
     }
 
     if request.method == "POST" && request.path == "/internal/reminder/scan" {
-        let Some(reminder_service) = reminder_service else {
+        let Some(data) = data else {
             return json_response(503, r#"{"error":"reminder scan disabled"}"#);
         };
-        return match reminder_service.scan_and_send().await {
+        return match data.reminder_service.scan_and_send().await {
             Ok(sent_count) => json_response(200, &format!(r#"{{"sent":{sent_count}}}"#)),
             Err(e) => {
                 tracing::error!("birthday reminder scan failed: {}", e);
@@ -115,24 +112,21 @@ async fn handle_request(request: &[u8], reminder_service: Option<&ReminderServic
     String::from_utf8_lossy(response_bytes()).to_string()
 }
 
-fn handle_discord_interaction(request: &HttpRequest<'_>) -> String {
+async fn handle_discord_interaction(request: &HttpRequest<'_>, data: Option<&Data>) -> String {
     if let Err(e) = verify_discord_signature(request) {
         tracing::warn!("Discord interaction signature verification failed: {}", e);
         return json_response(401, r#"{"error":"invalid request signature"}"#);
     }
 
-    let interaction = match serde_json::from_slice::<DiscordInteraction>(request.body) {
-        Ok(interaction) => interaction,
+    let response = match handle_interaction_body(data, request.body).await {
+        Ok(response) => response,
         Err(e) => {
-            tracing::warn!("Discord interaction JSON parse failed: {}", e);
+            tracing::warn!("Discord interaction handling failed: {}", e);
             return json_response(400, r#"{"error":"bad request"}"#);
         }
     };
 
-    match interaction.interaction_type {
-        1 => json_response(200, r#"{"type":1}"#),
-        _ => json_response(400, r#"{"error":"unsupported interaction type"}"#),
-    }
+    webhook_response(response)
 }
 
 fn verify_discord_signature(request: &HttpRequest<'_>) -> Result<(), &'static str> {
@@ -199,16 +193,32 @@ fn request_head_for_log(request: &[u8]) -> String {
 }
 
 fn json_response(status: u16, body: &str) -> String {
+    http_response(status, Some("application/json"), body)
+}
+
+fn webhook_response(response: WebhookHttpResponse) -> String {
+    if response.body.is_empty() {
+        http_response(response.status, None, "")
+    } else {
+        http_response(response.status, Some("application/json"), &response.body)
+    }
+}
+
+fn http_response(status: u16, content_type: Option<&str>, body: &str) -> String {
     let status_text = match status {
         200 => "OK",
+        204 => "No Content",
         400 => "Bad Request",
         401 => "Unauthorized",
         503 => "Service Unavailable",
         500 => "Internal Server Error",
         _ => "OK",
     };
+    let content_type = content_type
+        .map(|value| format!("Content-Type: {value}\r\n"))
+        .unwrap_or_default();
     format!(
-        "HTTP/1.1 {status} {status_text}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        "HTTP/1.1 {status} {status_text}\r\n{content_type}Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
         body.len()
     )
 }
@@ -250,12 +260,6 @@ impl<'a> HttpRequest<'a> {
             header_name.eq_ignore_ascii_case(name).then_some(*value)
         })
     }
-}
-
-#[derive(Debug, Deserialize)]
-struct DiscordInteraction {
-    #[serde(rename = "type")]
-    interaction_type: u8,
 }
 
 #[cfg(test)]
@@ -316,7 +320,7 @@ mod tests {
 
     #[tokio::test]
     async fn discord_interaction_returns_error_for_unsupported_type() {
-        let request = signed_interaction_request(r#"{"type":2}"#);
+        let request = signed_interaction_request(r#"{"type":99}"#);
 
         let response = handle_request(request.as_bytes(), None).await;
 

--- a/src/services/interaction_webhook.rs
+++ b/src/services/interaction_webhook.rs
@@ -1,0 +1,571 @@
+use crate::handler::interaction::handle_component_interaction;
+use crate::models::common::Data;
+use crate::reminder::ui;
+use crate::res::colors::EMBED_COLOR_WARNING;
+use crate::usecase::birth_list_usecase::BirthListView;
+use crate::usecase::birth_reset_usecase::webhook_reset_button_custom_id;
+use crate::usecase::birth_signup_usecase::BirthSignupResult;
+use anyhow::Context as _;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use serenity::all::{GuildId, Interaction};
+
+const INTERACTION_TYPE_PING: u8 = 1;
+const INTERACTION_TYPE_APPLICATION_COMMAND: u8 = 2;
+const INTERACTION_TYPE_COMPONENT: u8 = 3;
+const INTERACTION_TYPE_MODAL_SUBMIT: u8 = 5;
+const RESPONSE_TYPE_PONG: u8 = 1;
+const RESPONSE_TYPE_CHANNEL_MESSAGE: u8 = 4;
+const RESPONSE_TYPE_MODAL: u8 = 9;
+const EPHEMERAL_FLAG: u64 = 64;
+const BIRTH_SIGNUP_MODAL_ID: &str = "birth_signup";
+const BIRTH_SIGNUP_INPUT_ID: &str = "birth_input";
+
+pub struct WebhookHttpResponse {
+    pub status: u16,
+    pub body: String,
+}
+
+impl WebhookHttpResponse {
+    pub fn json(status: u16, body: Value) -> Self {
+        Self {
+            status,
+            body: body.to_string(),
+        }
+    }
+
+    pub fn empty(status: u16) -> Self {
+        Self {
+            status,
+            body: String::new(),
+        }
+    }
+}
+
+pub async fn handle_interaction_body(
+    data: Option<&Data>,
+    body: &[u8],
+) -> anyhow::Result<WebhookHttpResponse> {
+    let interaction = serde_json::from_slice::<DiscordInteraction>(body)
+        .context("Discord interaction JSON parse failed")?;
+
+    match interaction.interaction_type {
+        INTERACTION_TYPE_PING => Ok(WebhookHttpResponse::json(
+            200,
+            json!({ "type": RESPONSE_TYPE_PONG }),
+        )),
+        INTERACTION_TYPE_APPLICATION_COMMAND => {
+            let data = data.context("interaction handler is disabled")?;
+            handle_application_command(data, interaction).await
+        }
+        INTERACTION_TYPE_COMPONENT => {
+            let data = data.context("interaction handler is disabled")?;
+            handle_component(data, body).await
+        }
+        INTERACTION_TYPE_MODAL_SUBMIT => {
+            let data = data.context("interaction handler is disabled")?;
+            handle_modal_submit(data, interaction).await
+        }
+        _ => Ok(WebhookHttpResponse::json(
+            400,
+            json!({ "error": "unsupported interaction type" }),
+        )),
+    }
+}
+
+async fn handle_application_command(
+    data: &Data,
+    interaction: DiscordInteraction,
+) -> anyhow::Result<WebhookHttpResponse> {
+    let guild_id = interaction.guild_id;
+    let member_id = interaction.user_id();
+    let command_data = interaction
+        .data
+        .context("application command data missing")?;
+    let route = ApplicationCommandRoute::from_command_data(&command_data)
+        .context("unsupported application command")?;
+
+    match route {
+        ApplicationCommandRoute::Hello => Ok(discord_response(message("こんにちは、なのだ!"))),
+        ApplicationCommandRoute::BirthList => {
+            if let Err(e) = data.guild_update_usecase.invoke().await {
+                tracing::warn!("Guild sync failed before webhook birth list: {}", e);
+            }
+
+            let guild_id = guild_id.context("guild id missing")?;
+            let view = data
+                .birth_list_usecase
+                .build_view(GuildId::new(u64::try_from(guild_id)?))
+                .await?;
+            Ok(discord_response(birth_list_message(&view)))
+        }
+        ApplicationCommandRoute::BirthSignup => Ok(discord_response(signup_modal())),
+        ApplicationCommandRoute::BirthReset => {
+            let guild_id = guild_id.context("guild id missing")?;
+            let member_id = member_id.context("user id missing")?;
+            let view = data
+                .birth_reset_usecase
+                .build_confirmation_view(guild_id, Some(&format!("guild-{guild_id}")), member_id)
+                .await?;
+            if view.has_birth {
+                Ok(discord_response(birth_reset_confirmation_message(
+                    guild_id, member_id,
+                )))
+            } else {
+                Ok(discord_response(embed_message(
+                    "⚠️ 誕生日が登録されていないのだ",
+                    EMBED_COLOR_WARNING,
+                )))
+            }
+        }
+        ApplicationCommandRoute::BirthRemindResume => {
+            let guild_id = guild_id.context("guild id missing")?;
+            let member_id = member_id.context("user id missing")?;
+            data.reminder_service
+                .resume_reminder(guild_id, member_id)
+                .await?;
+            Ok(discord_response(message("リマインドを再開したのだ！")))
+        }
+        ApplicationCommandRoute::SetupReminderChannel => {
+            let guild_id = guild_id.context("guild id missing")?;
+            let member_id = member_id.context("user id missing")?;
+            if !data.reminder_service.is_admin_member(member_id).await? {
+                return Ok(discord_response(message(
+                    "このコマンドを実行する権限がないのだ。",
+                )));
+            }
+
+            if let Err(e) = data.guild_update_usecase.invoke().await {
+                tracing::warn!("Guild sync failed before webhook reminder setup: {}", e);
+            }
+
+            let session_id = data
+                .reminder_service
+                .create_selection_session(member_id, guild_id)?;
+            Ok(discord_response(setup_reminder_channel_message(
+                member_id,
+                guild_id,
+                &session_id,
+            )))
+        }
+        ApplicationCommandRoute::SetupAddNotificationChannel => {
+            manage_notification_channel(data, guild_id, member_id, &command_data, true).await
+        }
+        ApplicationCommandRoute::SetupRemoveNotificationChannel => {
+            manage_notification_channel(data, guild_id, member_id, &command_data, false).await
+        }
+    }
+}
+
+async fn handle_component(data: &Data, body: &[u8]) -> anyhow::Result<WebhookHttpResponse> {
+    let interaction = serde_json::from_slice::<Interaction>(body)
+        .context("Discord component interaction JSON parse failed")?;
+    let Interaction::Component(component) = interaction else {
+        anyhow::bail!("interaction payload was not a component");
+    };
+
+    match handle_component_interaction(data, &component).await {
+        Ok(true) => Ok(WebhookHttpResponse::empty(204)),
+        Ok(false) => Ok(WebhookHttpResponse::json(
+            400,
+            json!({ "error": "unsupported component interaction" }),
+        )),
+        Err(e) => Err(e),
+    }
+}
+
+async fn handle_modal_submit(
+    data: &Data,
+    interaction: DiscordInteraction,
+) -> anyhow::Result<WebhookHttpResponse> {
+    let guild_id = interaction.guild_id.context("guild id missing")?;
+    let member_id = interaction.user_id().context("user id missing")?;
+    let command_data = interaction.data.context("modal submit data missing")?;
+    if command_data.custom_id.as_deref() != Some(BIRTH_SIGNUP_MODAL_ID) {
+        return Ok(WebhookHttpResponse::json(
+            400,
+            json!({ "error": "unsupported modal submit" }),
+        ));
+    }
+
+    let input_birth = command_data
+        .modal_text_value(BIRTH_SIGNUP_INPUT_ID)
+        .context("birth signup modal input missing")?;
+    let result = data
+        .birth_signup_usecase
+        .register_birth(
+            guild_id,
+            Some(&format!("guild-{guild_id}")),
+            member_id,
+            &input_birth,
+        )
+        .await?;
+    Ok(discord_response(signup_result_message(&result)))
+}
+
+async fn manage_notification_channel(
+    data: &Data,
+    guild_id: Option<i64>,
+    member_id: Option<i64>,
+    command_data: &ApplicationCommandData,
+    add: bool,
+) -> anyhow::Result<WebhookHttpResponse> {
+    let guild_id = guild_id.context("guild id missing")?;
+    let member_id = member_id.context("user id missing")?;
+    if !data.reminder_service.is_admin_member(member_id).await? {
+        return Ok(discord_response(message(
+            "このコマンドを実行する権限がないのだ。",
+        )));
+    }
+
+    let channel_id = command_data
+        .subcommand_option_value("channel")
+        .and_then(value_as_i64)
+        .context("channel option missing")?;
+
+    if add {
+        data.reminder_service
+            .add_notification_channel(guild_id, channel_id)
+            .await?;
+    } else {
+        data.reminder_service
+            .remove_notification_channel(guild_id, channel_id)
+            .await?;
+    }
+
+    let content = if add {
+        format!("<#{channel_id}> を通知チャンネルに追加したのだ！")
+    } else {
+        format!("<#{channel_id}> を通知チャンネルから削除したのだ！")
+    };
+    Ok(discord_response(message(&content)))
+}
+
+fn discord_response(body: Value) -> WebhookHttpResponse {
+    WebhookHttpResponse::json(200, body)
+}
+
+fn message(content: &str) -> Value {
+    json!({
+        "type": RESPONSE_TYPE_CHANNEL_MESSAGE,
+        "data": {
+            "content": content,
+            "flags": EPHEMERAL_FLAG
+        }
+    })
+}
+
+fn embed_message(title: &str, color: u32) -> Value {
+    json!({
+        "type": RESPONSE_TYPE_CHANNEL_MESSAGE,
+        "data": {
+            "embeds": [{ "title": title, "color": color }],
+            "flags": EPHEMERAL_FLAG
+        }
+    })
+}
+
+fn birth_list_message(view: &BirthListView) -> Value {
+    let mut embed = json!({
+        "title": view.title(),
+        "color": view.color()
+    });
+    if let Some(description) = view.description() {
+        embed["description"] = json!(description);
+    }
+
+    json!({
+        "type": RESPONSE_TYPE_CHANNEL_MESSAGE,
+        "data": {
+            "embeds": [embed],
+            "flags": EPHEMERAL_FLAG
+        }
+    })
+}
+
+fn signup_modal() -> Value {
+    json!({
+        "type": RESPONSE_TYPE_MODAL,
+        "data": {
+            "custom_id": BIRTH_SIGNUP_MODAL_ID,
+            "title": "誕生日の通知登録",
+            "components": [{
+                "type": 1,
+                "components": [{
+                    "type": 4,
+                    "custom_id": BIRTH_SIGNUP_INPUT_ID,
+                    "label": "自身の誕生日を入力するのだ",
+                    "style": 1,
+                    "placeholder": "02/01",
+                    "min_length": 5,
+                    "max_length": 5,
+                    "required": true
+                }]
+            }]
+        }
+    })
+}
+
+fn signup_result_message(result: &BirthSignupResult) -> Value {
+    let mut data = json!({
+        "embeds": [{
+            "title": result.title(),
+            "color": result.color()
+        }],
+        "flags": EPHEMERAL_FLAG
+    });
+    if let Some(content) = result.content() {
+        data["content"] = json!(content);
+    }
+
+    json!({
+        "type": RESPONSE_TYPE_CHANNEL_MESSAGE,
+        "data": data
+    })
+}
+
+fn birth_reset_confirmation_message(guild_id: i64, member_id: i64) -> Value {
+    json!({
+        "type": RESPONSE_TYPE_CHANNEL_MESSAGE,
+        "data": {
+            "content": "誕生日の通知登録を解除するのだ⚠️",
+            "flags": EPHEMERAL_FLAG,
+            "components": [{
+                "type": 1,
+                "components": [{
+                    "type": 2,
+                    "custom_id": webhook_reset_button_custom_id(guild_id, member_id),
+                    "label": "解除",
+                    "style": 4
+                }]
+            }]
+        }
+    })
+}
+
+fn setup_reminder_channel_message(member_id: i64, guild_id: i64, session_id: &str) -> Value {
+    json!({
+        "type": RESPONSE_TYPE_CHANNEL_MESSAGE,
+        "data": {
+            "content": "リマインドを送るユーザーを選ぶのだ！",
+            "flags": EPHEMERAL_FLAG,
+            "components": [{
+                "type": 1,
+                "components": [{
+                    "type": 2,
+                    "custom_id": ui::start_button_custom_id(member_id, guild_id, session_id),
+                    "label": "ユーザーを選ぶのだ",
+                    "style": 1
+                }]
+            }]
+        }
+    })
+}
+
+fn value_as_i64(value: &Value) -> Option<i64> {
+    value
+        .as_i64()
+        .or_else(|| value.as_u64().and_then(|value| i64::try_from(value).ok()))
+        .or_else(|| value.as_str()?.parse::<i64>().ok())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApplicationCommandRoute {
+    Hello,
+    BirthList,
+    BirthSignup,
+    BirthReset,
+    BirthRemindResume,
+    SetupReminderChannel,
+    SetupAddNotificationChannel,
+    SetupRemoveNotificationChannel,
+}
+
+impl ApplicationCommandRoute {
+    fn from_command_data(data: &ApplicationCommandData) -> Option<Self> {
+        match data.name.as_str() {
+            "hello" => Some(Self::Hello),
+            "birth" => match data.options.first()?.name.as_str() {
+                "list" => Some(Self::BirthList),
+                "signup" => Some(Self::BirthSignup),
+                "reset" => Some(Self::BirthReset),
+                "remind" => {
+                    let nested = data.options.first()?.options.first()?;
+                    (nested.name == "resume").then_some(Self::BirthRemindResume)
+                }
+                _ => None,
+            },
+            "setup" => match data.options.first()?.name.as_str() {
+                "reminder-channel" => Some(Self::SetupReminderChannel),
+                "add-notification-channel" => Some(Self::SetupAddNotificationChannel),
+                "remove-notification-channel" => Some(Self::SetupRemoveNotificationChannel),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct DiscordInteraction {
+    #[serde(rename = "type")]
+    interaction_type: u8,
+    #[serde(default, deserialize_with = "deserialize_optional_i64")]
+    guild_id: Option<i64>,
+    member: Option<InteractionMember>,
+    user: Option<InteractionUser>,
+    data: Option<ApplicationCommandData>,
+}
+
+impl DiscordInteraction {
+    fn user_id(&self) -> Option<i64> {
+        self.member
+            .as_ref()
+            .and_then(|member| member.user.as_ref())
+            .map(|user| user.id)
+            .or_else(|| self.user.as_ref().map(|user| user.id))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct InteractionMember {
+    user: Option<InteractionUser>,
+}
+
+#[derive(Debug, Deserialize)]
+struct InteractionUser {
+    #[serde(deserialize_with = "deserialize_i64")]
+    id: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct ApplicationCommandData {
+    name: String,
+    #[serde(default)]
+    custom_id: Option<String>,
+    #[serde(default)]
+    options: Vec<ApplicationCommandOption>,
+    #[serde(default)]
+    components: Vec<ModalActionRow>,
+}
+
+impl ApplicationCommandData {
+    fn subcommand_option_value(&self, option_name: &str) -> Option<&Value> {
+        self.options
+            .first()?
+            .options
+            .iter()
+            .find(|option| option.name == option_name)?
+            .value
+            .as_ref()
+    }
+
+    fn modal_text_value(&self, custom_id: &str) -> Option<String> {
+        self.components
+            .iter()
+            .flat_map(|row| row.components.iter())
+            .find(|component| component.custom_id == custom_id)?
+            .value
+            .clone()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ApplicationCommandOption {
+    name: String,
+    #[serde(default)]
+    value: Option<Value>,
+    #[serde(default)]
+    options: Vec<ApplicationCommandOption>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModalActionRow {
+    #[serde(default)]
+    components: Vec<ModalComponent>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ModalComponent {
+    custom_id: String,
+    value: Option<String>,
+}
+
+fn deserialize_optional_i64<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<Value>::deserialize(deserializer)?;
+    value
+        .map(|value| {
+            value_as_i64(&value).ok_or_else(|| serde::de::Error::custom("invalid integer value"))
+        })
+        .transpose()
+}
+
+fn deserialize_i64<'de, D>(deserializer: D) -> Result<i64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Value::deserialize(deserializer)?;
+    value_as_i64(&value).ok_or_else(|| serde::de::Error::custom("invalid integer value"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn command_data(body: &str) -> ApplicationCommandData {
+        serde_json::from_str::<DiscordInteraction>(body)
+            .expect("interaction should parse")
+            .data
+            .expect("command data should exist")
+    }
+
+    #[test]
+    fn routes_hello_command() {
+        let data = command_data(r#"{"type":2,"data":{"name":"hello","options":[]}}"#);
+
+        assert_eq!(
+            ApplicationCommandRoute::from_command_data(&data),
+            Some(ApplicationCommandRoute::Hello)
+        );
+    }
+
+    #[test]
+    fn routes_nested_birth_remind_resume_command() {
+        let data = command_data(
+            r#"{"type":2,"data":{"name":"birth","options":[{"name":"remind","options":[{"name":"resume"}]}]}}"#,
+        );
+
+        assert_eq!(
+            ApplicationCommandRoute::from_command_data(&data),
+            Some(ApplicationCommandRoute::BirthRemindResume)
+        );
+    }
+
+    #[test]
+    fn reads_channel_option_from_setup_subcommand() {
+        let data = command_data(
+            r#"{"type":2,"data":{"name":"setup","options":[{"name":"add-notification-channel","options":[{"name":"channel","value":"123"}]}]}}"#,
+        );
+
+        assert_eq!(
+            data.subcommand_option_value("channel")
+                .and_then(value_as_i64),
+            Some(123)
+        );
+    }
+
+    #[test]
+    fn reads_birth_signup_modal_value() {
+        let data = command_data(
+            r#"{"type":5,"data":{"name":"","custom_id":"birth_signup","components":[{"components":[{"custom_id":"birth_input","value":"02/01"}]}]}}"#,
+        );
+
+        assert_eq!(
+            data.modal_text_value(BIRTH_SIGNUP_INPUT_ID),
+            Some("02/01".to_string())
+        );
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,1 +1,2 @@
 pub mod healthcheck;
+pub mod interaction_webhook;

--- a/src/usecase/birth_list_usecase.rs
+++ b/src/usecase/birth_list_usecase.rs
@@ -4,10 +4,11 @@ use crate::res::colors::{EMBED_COLOR_SUCCESS, EMBED_COLOR_WARNING};
 use chrono::Datelike;
 use poise::futures_util::future::join_all;
 use poise::CreateReply;
-use serenity::all::{CreateEmbed, Http};
+use serenity::all::{CreateEmbed, GuildId, Http};
 use sqlx::PgPool;
 use std::sync::Arc;
 
+#[derive(Clone)]
 pub struct BirthListUsecase {
     guild_repo: GuildRepository,
     http: Arc<Http>,
@@ -29,6 +30,13 @@ impl BirthListUsecase {
             .fetch_guild_id_from_command(poise_ctx)
             .await?;
 
+        let view = self.build_view(guild_id).await?;
+        poise_ctx.send(view.into_reply()).await?;
+
+        Ok(())
+    }
+
+    pub async fn build_view(&self, guild_id: GuildId) -> anyhow::Result<BirthListView> {
         // ギルドIDに一致するメンバー情報リストをguild_memberテーブルから取得
         let mut members = self
             .guild_repo
@@ -39,15 +47,9 @@ impl BirthListUsecase {
             .filter(|member| member.birth.is_some())
             .collect::<Vec<_>>();
 
-        let reply = if members.is_empty() {
+        if members.is_empty() {
             // 「誕生日通知を登録しているメンバーがいないこと」をメッセージで通知
-            CreateReply::default()
-                .embed(
-                    CreateEmbed::new()
-                        .title("⚠️ 誕生日が登録されていないのだ")
-                        .color(EMBED_COLOR_WARNING), // 警告系の色
-                )
-                .ephemeral(true)
+            Ok(BirthListView::Empty)
         } else {
             // メンバー情報リストが誕生日の降順になるようにソート
             members.sort_by_key(|m| m.birth.map(|b| (b.month(), b.day())));
@@ -69,17 +71,57 @@ impl BirthListUsecase {
                 .into_iter()
                 .flatten()
                 .collect::<Vec<_>>();
-            CreateReply::default()
+            Ok(BirthListView::List {
+                description: birth_list.join(""),
+            })
+        }
+    }
+}
+
+pub enum BirthListView {
+    Empty,
+    List { description: String },
+}
+
+impl BirthListView {
+    pub fn into_reply(self) -> CreateReply {
+        match self {
+            Self::Empty => CreateReply::default()
+                .embed(
+                    CreateEmbed::new()
+                        .title("⚠️ 誕生日が登録されていないのだ")
+                        .color(EMBED_COLOR_WARNING),
+                )
+                .ephemeral(true),
+            Self::List { description } => CreateReply::default()
                 .embed(
                     CreateEmbed::new()
                         .title("🎉 誕生日リスト")
-                        .description(birth_list.join(""))
-                        .color(EMBED_COLOR_SUCCESS), // 正常系の色
+                        .description(description)
+                        .color(EMBED_COLOR_SUCCESS),
                 )
-                .ephemeral(true)
-        };
-        poise_ctx.send(reply).await?;
+                .ephemeral(true),
+        }
+    }
 
-        Ok(())
+    pub fn title(&self) -> &'static str {
+        match self {
+            Self::Empty => "⚠️ 誕生日が登録されていないのだ",
+            Self::List { .. } => "🎉 誕生日リスト",
+        }
+    }
+
+    pub fn color(&self) -> u32 {
+        match self {
+            Self::Empty => EMBED_COLOR_WARNING,
+            Self::List { .. } => EMBED_COLOR_SUCCESS,
+        }
+    }
+
+    pub fn description(&self) -> Option<&str> {
+        match self {
+            Self::Empty => None,
+            Self::List { description } => Some(description),
+        }
     }
 }

--- a/src/usecase/birth_reset_usecase.rs
+++ b/src/usecase/birth_reset_usecase.rs
@@ -7,6 +7,9 @@ use sqlx::PgPool;
 use std::sync::Arc;
 use std::time::Duration;
 
+pub const WEBHOOK_RESET_BUTTON_PREFIX: &str = "birth_reset_confirm";
+
+#[derive(Clone)]
 pub struct BirthResetUsecase {
     guild_repo: GuildRepository,
 }
@@ -32,21 +35,11 @@ impl BirthResetUsecase {
         // コマンドを実行したメンバーのメンバーIDを取得
         let member_id = i64::from(poise_ctx.author().id);
 
-        // 初回参加メンバーでも参照できるよう、対象レコードを事前に作成しておく
-        self.guild_repo
-            .add_guild(guild_id, Some(guild_name.as_str()))
-            .await?;
-        self.guild_repo
-            .add_member(guild_id, member_id, None)
+        let view = self
+            .build_confirmation_view(guild_id, Some(guild_name.as_str()), member_id)
             .await?;
 
-        // ギルドIDとメンバーIDに一致するメンバーの誕生日をguild_memberテーブルから取得
-        let member_birth = self
-            .guild_repo
-            .get_member_birth(guild_id, member_id)
-            .await?;
-
-        if member_birth.is_none() {
+        if !view.has_birth {
             // 「誕生日が登録されていないこと」をメッセージで通知
             poise_ctx
                 .send(
@@ -90,9 +83,7 @@ impl BirthResetUsecase {
 
                     // ユーザーが「解除」ボタンを押下
                     // guild_memberテーブルの誕生日と最終通知日をNULLに更新
-                    self.guild_repo
-                        .reset_member_birth(guild_id, member_id)
-                        .await?;
+                    self.reset_member_birth(guild_id, member_id).await?;
 
                     // 誕生日解除の確認メッセージと「解除」ボタンを削除
                     reply_handle
@@ -122,5 +113,56 @@ impl BirthResetUsecase {
             }
         }
         Ok(())
+    }
+
+    pub async fn build_confirmation_view(
+        &self,
+        guild_id: i64,
+        guild_name: Option<&str>,
+        member_id: i64,
+    ) -> anyhow::Result<BirthResetConfirmationView> {
+        // 初回参加メンバーでも参照できるよう、対象レコードを事前に作成しておく
+        self.guild_repo.add_guild(guild_id, guild_name).await?;
+        self.guild_repo
+            .add_member(guild_id, member_id, None)
+            .await?;
+
+        // ギルドIDとメンバーIDに一致するメンバーの誕生日をguild_memberテーブルから取得
+        let member_birth = self
+            .guild_repo
+            .get_member_birth(guild_id, member_id)
+            .await?;
+
+        Ok(BirthResetConfirmationView {
+            has_birth: member_birth.is_some(),
+        })
+    }
+
+    pub async fn reset_member_birth(&self, guild_id: i64, member_id: i64) -> anyhow::Result<()> {
+        self.guild_repo
+            .reset_member_birth(guild_id, member_id)
+            .await?;
+        Ok(())
+    }
+}
+
+pub struct BirthResetConfirmationView {
+    pub has_birth: bool,
+}
+
+pub fn webhook_reset_button_custom_id(guild_id: i64, member_id: i64) -> String {
+    format!("{WEBHOOK_RESET_BUTTON_PREFIX}:{guild_id}:{member_id}")
+}
+
+pub fn parse_webhook_reset_button_custom_id(custom_id: &str) -> Option<(i64, i64)> {
+    let mut parts = custom_id.split(':');
+    let prefix = parts.next()?;
+    let guild_id = parts.next()?.parse::<i64>().ok()?;
+    let member_id = parts.next()?.parse::<i64>().ok()?;
+
+    if prefix == WEBHOOK_RESET_BUTTON_PREFIX && parts.next().is_none() {
+        Some((guild_id, member_id))
+    } else {
+        None
     }
 }

--- a/src/usecase/birth_signup_usecase.rs
+++ b/src/usecase/birth_signup_usecase.rs
@@ -7,6 +7,7 @@ use serenity::all::{CreateEmbed, Http};
 use sqlx::PgPool;
 use std::sync::Arc;
 
+#[derive(Clone)]
 pub struct BirthSignupUsecase {
     guild_repo: GuildRepository,
     reminder_service: crate::reminder::service::ReminderService,
@@ -38,23 +39,6 @@ impl BirthSignupUsecase {
         // 以降の応答は defer してから行う必要がある。
         poise_ctx.defer_ephemeral().await?;
 
-        let birth = NaiveDate::parse_from_str(&format!("2000/{input_birth}"), "%Y/%m/%d");
-        if birth.is_err() {
-            // 誕生日の入力フォーマットが無効
-            poise_ctx
-                .send(
-                    CreateReply::default()
-                        .embed(
-                            CreateEmbed::new()
-                                .title("🚨  誕生日が正しいフォーマットで入力されていないのだ。")
-                                .color(EMBED_COLOR_ERROR), // 異常系の色
-                        )
-                        .ephemeral(true),
-                )
-                .await?;
-            return Ok(());
-        }
-
         // コマンドが実行されたギルドのギルドIDを取得
         let guild_id = self
             .guild_repo
@@ -69,10 +53,28 @@ impl BirthSignupUsecase {
         // コマンドを実行したメンバーのメンバーIDを取得;
         let member_id = i64::from(poise_ctx.author().id);
 
-        // 初回参加メンバーでも登録できるよう、対象レコードを事前に作成しておく
-        self.guild_repo
-            .add_guild(guild_id, Some(guild_name.as_str()))
+        let result = self
+            .register_birth(guild_id, Some(guild_name.as_str()), member_id, &input_birth)
             .await?;
+        poise_ctx.send(result.into_reply()).await?;
+
+        Ok(())
+    }
+
+    pub async fn register_birth(
+        &self,
+        guild_id: i64,
+        guild_name: Option<&str>,
+        member_id: i64,
+        input_birth: &str,
+    ) -> anyhow::Result<BirthSignupResult> {
+        let Ok(birth) = NaiveDate::parse_from_str(&format!("2000/{input_birth}"), "%Y/%m/%d")
+        else {
+            return Ok(BirthSignupResult::InvalidFormat);
+        };
+
+        // 初回参加メンバーでも登録できるよう、対象レコードを事前に作成しておく
+        self.guild_repo.add_guild(guild_id, guild_name).await?;
         self.guild_repo
             .add_member(guild_id, member_id, None)
             .await?;
@@ -87,7 +89,7 @@ impl BirthSignupUsecase {
             // メンバー情報に誕生日が存在しない
             // guild_memberテーブルのメンバーIDに一致するにメンバーの誕生日を更新
             self.guild_repo
-                .update_member_birth(guild_id, member_id, birth?)
+                .update_member_birth(guild_id, member_id, birth)
                 .await?;
 
             if let Err(e) = self
@@ -103,36 +105,68 @@ impl BirthSignupUsecase {
                 );
             }
 
-            // 「誕生日通知の登録が完了したこと」をメッセージで通知
-            poise_ctx
-                .send(
-                    CreateReply::default()
-                        .embed(
-                            CreateEmbed::new()
-                                .title("✅  誕生日の通知登録が完了したのだ。")
-                                .color(EMBED_COLOR_SUCCESS), // 正常系の色
-                        )
-                        .content("登録した日付の正午（12:00）に誕生日が通知されるのだ。")
-                        .ephemeral(true),
-                )
-                .await?;
+            Ok(BirthSignupResult::Registered)
         } else {
-            // メンバー情報に誕生日が存在する
-            // 「すでに誕生日通知が登録済であること」をメッセージで通知
-            poise_ctx
-                .send(
-                    CreateReply::default()
-                        .embed(
-                            CreateEmbed::new()
-                                .title("⚠️ 誕生日はすでに登録済みなのだ")
-                                .color(EMBED_COLOR_WARNING), // 警告系の色
-                        )
-                        .ephemeral(true),
-                )
-                .await?;
+            Ok(BirthSignupResult::AlreadyRegistered)
         }
+    }
+}
 
-        Ok(())
+pub enum BirthSignupResult {
+    InvalidFormat,
+    Registered,
+    AlreadyRegistered,
+}
+
+impl BirthSignupResult {
+    pub fn into_reply(self) -> CreateReply {
+        match self {
+            Self::InvalidFormat => CreateReply::default()
+                .embed(
+                    CreateEmbed::new()
+                        .title("🚨  誕生日が正しいフォーマットで入力されていないのだ。")
+                        .color(EMBED_COLOR_ERROR),
+                )
+                .ephemeral(true),
+            Self::Registered => CreateReply::default()
+                .embed(
+                    CreateEmbed::new()
+                        .title("✅  誕生日の通知登録が完了したのだ。")
+                        .color(EMBED_COLOR_SUCCESS),
+                )
+                .content("登録した日付の正午（12:00）に誕生日が通知されるのだ。")
+                .ephemeral(true),
+            Self::AlreadyRegistered => CreateReply::default()
+                .embed(
+                    CreateEmbed::new()
+                        .title("⚠️ 誕生日はすでに登録済みなのだ")
+                        .color(EMBED_COLOR_WARNING),
+                )
+                .ephemeral(true),
+        }
+    }
+
+    pub fn title(&self) -> &'static str {
+        match self {
+            Self::InvalidFormat => "🚨  誕生日が正しいフォーマットで入力されていないのだ。",
+            Self::Registered => "✅  誕生日の通知登録が完了したのだ。",
+            Self::AlreadyRegistered => "⚠️ 誕生日はすでに登録済みなのだ",
+        }
+    }
+
+    pub fn color(&self) -> u32 {
+        match self {
+            Self::InvalidFormat => EMBED_COLOR_ERROR,
+            Self::Registered => EMBED_COLOR_SUCCESS,
+            Self::AlreadyRegistered => EMBED_COLOR_WARNING,
+        }
+    }
+
+    pub fn content(&self) -> Option<&'static str> {
+        match self {
+            Self::Registered => Some("登録した日付の正午（12:00）に誕生日が通知されるのだ。"),
+            Self::InvalidFormat | Self::AlreadyRegistered => None,
+        }
     }
 }
 

--- a/src/usecase/guild_update_usecase.rs
+++ b/src/usecase/guild_update_usecase.rs
@@ -8,6 +8,7 @@ use sqlx::PgPool;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+#[derive(Clone)]
 pub struct GuildUpdateUsecase {
     guild_repo: GuildRepository,
 }


### PR DESCRIPTION
## 概要

- Discord Gateway client の起動を廃止し、Cloud Run の HTTP webhook 運用へ切り替え
- slash command 登録を Gateway/Poise 起動ではなく Discord REST API 経由に変更
- 当日の誕生日通知を Cloud Scheduler などから `POST /internal/birthday/notify` で実行できるように変更
- `POST /interactions` と `POST /internal/reminder/scan` は継続して利用

Closes #25
Closes #26

## 作業内容

- `src/main.rs` から Gateway intents、Poise framework、Serenity Gateway client、内部誕生日通知ワーカー起動を削除
- `serenity` の直接利用 feature から `client` / `gateway` を外し、REST/webhook に必要な `http` / `model` に整理
- 起動時に `Http::new(DISCORD_TOKEN)` で REST client を作成し、usecase と healthcheck server を初期化
- `Command::set_global_commands` で `hello` / `birth` / `setup` の global slash command を登録
- `POST /internal/birthday/notify` を追加し、`BirthNotifyUsecase::invoke()` を Cloud Scheduler から呼べるように変更
- Gateway event 前提だった message/reaction activity 記録と Poise command 用 invoke/response 変換をコンパイル経路から除去
- README と UML を Gateway 前提から Interactions Endpoint + Cloud Scheduler 前提へ更新
- `/internal/birthday/notify` の routing test を追加

## 作業意図

- Cloud Run では Gateway 常時接続ではなく、Discord Interactions Endpoint URL と内部 HTTP endpoint を入口にするため
- 当日の誕生日通知をプロセス内の 24 時間 loop に依存させず、Cloud Scheduler から明示的に実行できるようにするため
- Gateway intents と message/reaction event handler に依存した起動処理をなくし、Webhook 運用時の責務を `src/services/healthcheck.rs` に集約するため

## 手動で次にするべき作業

- Discord Developer Portal の Interactions Endpoint URL に `https://{{SERVICE_URL}}/interactions` を設定して疎通確認する
- Cloud Scheduler 側で `POST /internal/reminder/scan` と `POST /internal/birthday/notify` を呼ぶジョブを設定または確認する
- 実 Discord 環境で `/hello`, `/birth`, `/setup` 系の webhook 応答を確認する

## 変更ファイル

- `.github/workflows/codex.yml`
- `AGENTS.md`
- `Cargo.toml`
- `README.md`
- `docs/ai/ARCHITECTURE.md`
- `docs/uml/birth_プッシュ通知.puml`
- `docs/uml/birth_未登録リマインド.puml`
- `docs/uml/初期化処理.puml`
- `docs/uml/整合性チェック.md`
- `src/data/guild_repository.rs`
- `src/data/zunda_bot_database.rs`
- `src/handler/interaction.rs`
- `src/handler/mod.rs`
- `src/main.rs`
- `src/models/common.rs`
- `src/reminder/service.rs`
- `src/reminder/ui.rs`
- `src/services/healthcheck.rs`
- `src/services/interaction_webhook.rs`
- `src/services/mod.rs`
- `src/usecase/birth_list_usecase.rs`
- `src/usecase/birth_notify_usecase.rs`
- `src/usecase/birth_reset_usecase.rs`
- `src/usecase/birth_signup_usecase.rs`
- `src/usecase/guild_update_usecase.rs`

## テスト結果

- `cargo fmt --check`: 成功
- `cargo clippy --all-targets --all-features -- -D warnings`: 成功
- `cargo test`: 成功（22 passed）

## 制限事項

- 実 Discord webhook endpoint と Cloud Scheduler からの手動疎通確認は未実施
- この Draft PR は #25 の Discord Interaction webhook 実装に #26 の Gateway 廃止を積んだ差分
- message create / reaction event の代替機能は Issue #26 の Non-goal のため追加していない
- `.github/workflows/codex.yml` と `AGENTS.md` の変更は #25 側の既存差分として PR に含まれている
