### PR TITLE
Discord Gatewayを廃止してWebhook運用へ移行

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["novum-d <example@gmail.com>"]
 
 [dependencies]
-serenity = { version = "0.12.0", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
+serenity = { version = "0.12.0", default-features = false, features = ["http", "rustls_backend", "model"] }
 poise = "0.6.1"
 anyhow = "1.0.98"
 tokio = { version = "1.45.1", features = ["io-util", "macros", "net", "rt-multi-thread", "time"] }

--- a/README.md
+++ b/README.md
@@ -29,10 +29,8 @@ Botの[トークンを作成](https://note.com/exteoi/n/nf1c37cb26c41)
 >このトークンを使ってBotプログラムがDiscord APIにアクセスし、メッセージ送信やイベント受信などの操作が可能になりますが、*
 *第三者に知られるとBotの乗っ取りなどの危険があるため、絶対に公開しないよう注意してください**
 
-1.2. ボットに特権を付与  
-ボット設定画面を開き、メニュー`Bot`
-で[Privileged Intents](https://discord.com/developers/docs/events/gateway#privileged-intents)に含まれるボットの
-`MESSAGE_CONTENT(メッセージ受取権限)`を有効化
+1.2. Discord Interactions Endpoint を設定
+Discord Developer Portal の General Information に表示される Public Key を控えます。デプロイ後、Interactions Endpoint URL に `https://{{SERVICE_URL}}/interactions` を設定します。
 
 1.3. 不要なセキュリティ設定を解除  
 Botをサーバーに追加する際に毎回認証を求められるので、`Requires OAuth2 Code Grant(Botをサーバーに追加する際に認証フローが必須となる設定)`
@@ -41,7 +39,7 @@ Botをサーバーに追加する際に毎回認証を求められるので、`R
 1.4. ボットをサーバーに追加  
 メニュー`OAuth`で`OAuth2 URL Generator`で以下を選択したURLをブラウザで開く
 
-* SCOPES: `bot`
+* SCOPES: `bot`, `applications.commands`
 * BOT PERMISSIONS: `Administrator`
 
    ```txt
@@ -146,15 +144,17 @@ gcloud run deploy zunda-bot-rs \
   --image {{REGION}}-docker.pkg.dev/{{PROJECT_ID}}/{{REPOSITORY}}/zunda-bot-rs \
   --region {{REGION}} \
   --allow-unauthenticated \
-  --set-env-vars DISCORD_PUBLIC_KEY={{DISCORD_PUBLIC_KEY}},ENABLE_DISCORD_BOT=true \
+  --set-env-vars DISCORD_PUBLIC_KEY={{DISCORD_PUBLIC_KEY}} \
   --set-secrets DISCORD_TOKEN={{DISCORD_TOKEN_SECRET}}:latest,DATABASE_URL={{DATABASE_URL_SECRET}}:latest
 ```
 
 Cloud Run の起動確認用に、コンテナは `PORT` 環境変数のポートで HTTP 200 を返します。
 Discord Developer Portal の Interactions Endpoint URL には `https://{{SERVICE_URL}}/interactions` を指定できます。`POST /interactions` は Discord の `X-Signature-Ed25519` / `X-Signature-Timestamp` を `DISCORD_PUBLIC_KEY` で検証し、PING interaction に応答します。`DISCORD_PUBLIC_KEY` が未設定の場合、署名検証ができないため Discord の interaction は利用できません。Cloud Run が未認証アクセスを拒否している場合も、Discord から検証リクエストを送れないため登録に失敗します。
+Discord Gateway には接続せず、slash command と component interaction は `POST /interactions` で受信します。起動時の slash command 登録も Discord REST API で行います。
 誕生日未登録リマインドは、送信時に `ずんだぼっと` という名前のテキストチャンネルを探します。存在しない場合は Bot が自動作成します。
 誕生日未登録リマインドを送信するには、`guild_member.is_admin` が `true` の管理者ユーザーが通知先にしたい Discord サーバーで `/setup reminder-channel` を実行します。この設定が完了するまで、ユーザーにはリマインド通知を送信しません。管理者コマンドの応答はエフェメラルで表示し、コマンド実行後は対象ユーザーをページング付きセレクトで選択して、選択したユーザーへ順次リマインドを送信できます。
-定期スキャンは、Cloud Scheduler などから `POST /internal/reminder/scan` を呼び出します。
+誕生日未登録リマインドの定期スキャンは、Cloud Scheduler などから `POST /internal/reminder/scan` を呼び出します。
+当日の誕生日通知は、Cloud Scheduler などから `POST /internal/birthday/notify` を呼び出します。
 
 5.8. デプロイ後のログ確認
 
@@ -164,7 +164,7 @@ gcloud run services logs read zunda-bot-rs \
   --limit=200
 ```
 
-5.9. Discord Gateway 接続維持のため、常時起動設定を行う
+5.9. Cloud Run の webhook 応答安定化のため、常時起動設定を行う
 
 ```shell
 gcloud run services update zunda-bot-rs \
@@ -179,7 +179,7 @@ gcloud run services update zunda-bot-rs \
 gcloud run services update zunda-bot-rs \
   --project "${GCP_PROJECT_ID}" \
   --region "${GCP_REGION}" \
-  --update-env-vars DISCORD_PUBLIC_KEY="${DISCORD_PUBLIC_KEY}",ENABLE_DISCORD_BOT=true
+  --update-env-vars DISCORD_PUBLIC_KEY="${DISCORD_PUBLIC_KEY}"
 ```
 
 5.10. 設定が反映されたことを確認

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ gcloud run deploy zunda-bot-rs \
 ```
 
 Cloud Run の起動確認用に、コンテナは `PORT` 環境変数のポートで HTTP 200 を返します。
-Discord Developer Portal の Interactions Endpoint URL には `https://{{SERVICE_URL}}/interactions` を指定できます。`POST /interactions` は Discord の `X-Signature-Ed25519` / `X-Signature-Timestamp` を `DISCORD_PUBLIC_KEY` で検証し、PING interaction に応答します。`DISCORD_PUBLIC_KEY` が未設定の場合、署名検証ができないため Discord の interaction は利用できません。Cloud Run が未認証アクセスを拒否している場合も、Discord から検証リクエストを送れないため登録に失敗します。
+Discord Developer Portal の Interactions Endpoint URL には `https://{{SERVICE_URL}}/interactions` を指定できます。`POST /interactions` は Discord の `X-Signature-Ed25519` / `X-Signature-Timestamp` を `DISCORD_PUBLIC_KEY` で検証し、PING interaction に応答します。`DISCORD_PUBLIC_KEY` が未設定の場合は `DISCORD_TOKEN` で Discord API から application verify key を取得して検証します。Cloud Run が未認証アクセスを拒否している場合は、Discord から検証リクエストを送れないため登録に失敗します。
 Discord Gateway には接続せず、slash command と component interaction は `POST /interactions` で受信します。起動時の slash command 登録も Discord REST API で行います。
 誕生日未登録リマインドは、送信時に `ずんだぼっと` という名前のテキストチャンネルを探します。存在しない場合は Bot が自動作成します。
 誕生日未登録リマインドを送信するには、`guild_member.is_admin` が `true` の管理者ユーザーが通知先にしたい Discord サーバーで `/setup reminder-channel` を実行します。この設定が完了するまで、ユーザーにはリマインド通知を送信しません。管理者コマンドの応答はエフェメラルで表示し、コマンド実行後は対象ユーザーをページング付きセレクトで選択して、選択したユーザーへ順次リマインドを送信できます。

--- a/README.md
+++ b/README.md
@@ -164,13 +164,24 @@ gcloud run services logs read zunda-bot-rs \
   --limit=200
 ```
 
-5.9. Cloud Run の webhook 応答安定化のため、常時起動設定を行う
+5.9. 必要に応じて Cloud Run の常時起動設定を行う
+
+起動直後は先に HTTP サーバーを起動し、DB 接続、ギルド同期、slash command 登録はバックグラウンドで行います。Discord interaction は処理に時間がかかる場合、先に defer 応答してから followup を送るため、Cloud Run の常時起動は必須ではありません。
+
+初回アクセスの cold start レイテンシを抑えたい場合のみ、最小インスタンスを設定します。
 
 ```shell
 gcloud run services update zunda-bot-rs \
   --region asia-northeast1 \
-  --min-instances=1 \
-  --no-cpu-throttling
+  --min-instances=1
+```
+
+コストを優先して scale to zero に戻す場合は、最小インスタンスを 0 にします。
+
+```shell
+gcloud run services update zunda-bot-rs \
+  --region asia-northeast1 \
+  --min-instances=0
 ```
 
 デプロイ済みサービスに Public Key だけを追加または更新する場合は、`GCP_PROJECT_ID` / `GCP_REGION` / `DISCORD_PUBLIC_KEY` を設定してから以下を実行します。

--- a/docs/uml/birth_プッシュ通知.puml
+++ b/docs/uml/birth_プッシュ通知.puml
@@ -2,6 +2,8 @@
 title 誕生日プッシュ通知の処理フロー
 start
 
+:Cloud SchedulerからPOST /internal/birthday/notifyを受信;
+
 :すべてのメンバー情報を含むリストをguild_memberテーブルから取得;
 
 :リストからメンバー情報を一つずつ取り出し、通知処理を実行;

--- a/docs/uml/birth_未登録リマインド.puml
+++ b/docs/uml/birth_未登録リマインド.puml
@@ -2,39 +2,14 @@
 title 誕生日未登録リマインド処理フロー
 
 ' --- 前提となる仕様 ----------------------
-' - BotユーザーとDMのアクティビティは記録しない
 ' - リマインド対象は誕生日未登録、停止していない、送信回数5回未満のメンバー
-' - アクティブ判定は直近7日以内のメッセージまたはリアクションで行う
+' - アクティブ判定はDBに保存済みのlast_active_atを使う
 ' - 同一メンバーへの送信間隔は24時間以上空ける
 ' ---------------------------------------
 
 start
 
 fork
-partition "メッセージ/リアクションによるアクティブ記録" {
-  :Discord Gatewayイベントを受信;
-  if (Botユーザー または DMイベント) is (はい) then
-    :処理を終了;
-  else (いいえ)
-  endif
-
-  :guildテーブルへ対象ギルドを追加（未登録時のみ）;
-  :guild_memberテーブルへ対象メンバーを追加（未登録時のみ）;
-  :last_active_atを現在日時に更新;
-  :next_remind_atがNULLの場合は現在日時+1日に更新;
-
-  :対象メンバーのリマインド候補を取得;
-  if (送信条件を満たす) is (はい) then
-    :ずんだぼっとチャンネルを取得または作成;
-    :リマインド停止ボタン付きメッセージを送信;
-    :reminder_channel_idとreminder_message_idを保存;
-    :last_reminded_at、next_remind_at、remind_countを更新;
-  else (いいえ)
-    :送信せず終了;
-  endif
-}
-
-fork again
 partition "内部スキャンAPIによる送信" {
   :POST /internal/reminder/scan を受信;
   if (ReminderServiceが無効) is (はい) then

--- a/docs/uml/初期化処理.puml
+++ b/docs/uml/初期化処理.puml
@@ -4,11 +4,34 @@ start
 
 :環境変数とログ設定を読み込む;
 
+:共有Data状態を作成;
+:バックグラウンド初期化タスクを起動;
+
+:Healthcheck serverを起動;
+note right
+  通常のhealthcheckに加えて
+  POST /internal/reminder/scan で
+  誕生日未登録リマインドのスキャンを実行できる。
+  POST /internal/birthday/notify で
+  当日の誕生日通知を実行できる。
+  POST /interactions で
+  Discord Interaction webhookを受信できる。
+
+  初期化完了前のDiscord Interactionには
+  起動処理中のエフェメラル応答を返す。
+end note
+
+partition "バックグラウンド初期化タスク" {
 :DATABASE_URLでPostgreSQLへ接続;
 :マイグレーションを実行;
 :DISCORD_TOKENを読み込む;
 
 :各UsecaseとReminderServiceを初期化;
+:共有Data状態へDataを公開;
+note right
+  以降、内部APIとDiscord Interactionは
+  実ユースケースを実行できる。
+end note
 
 ' 初期更新処理
 
@@ -75,22 +98,13 @@ endwhile
 }
 ' ----------------------------------------------------
 
+:Discord REST APIでApplication IDを取得;
 :Discord REST APIでグローバルslash commandを登録;
 note right
   hello、birth、setupを登録する。
   birthはlist/signup/reset/remind resumeを持つ。
 end note
-
-:Healthcheck serverを起動;
-note right
-  通常のhealthcheckに加えて
-  POST /internal/reminder/scan で
-  誕生日未登録リマインドのスキャンを実行できる。
-  POST /internal/birthday/notify で
-  当日の誕生日通知を実行できる。
-  POST /interactions で
-  Discord Interaction webhookを受信できる。
-end note
+}
 
 stop
 

--- a/docs/uml/初期化処理.puml
+++ b/docs/uml/初期化処理.puml
@@ -4,35 +4,9 @@ start
 
 :環境変数とログ設定を読み込む;
 
-if (ENABLE_DISCORD_BOT == "false") is (はい) then
-  :Passive healthcheck serverを起動;
-  :通常のhealthcheckと
-  POST /interactions に応答する;
-  stop
-else (いいえ)
-endif
-
 :DATABASE_URLでPostgreSQLへ接続;
 :マイグレーションを実行;
 :DISCORD_TOKENを読み込む;
-:Gateway Intentsを設定;
-note right
-  GUILD_MEMBERS、GUILD_MESSAGES、
-  GUILD_MESSAGE_REACTIONS、
-  DIRECT_MESSAGES、MESSAGE_CONTENTを利用する。
-end note
-
-:slash commandを登録;
-note right
-  hello、birth、setupを登録する。
-  birthはlist/signup/reset/remind resumeを持つ。
-end note
-
-:Discordイベントハンドラを設定;
-note right
-  MessageとReactionAddでアクティブ日時を記録する。
-  Component interactionでリマインド停止と選択UIを処理する。
-end note
 
 :各UsecaseとReminderServiceを初期化;
 
@@ -101,18 +75,22 @@ endwhile
 }
 ' ----------------------------------------------------
 
-:誕生日プッシュ通知ワーカーを起動;
+:Discord REST APIでグローバルslash commandを登録;
+note right
+  hello、birth、setupを登録する。
+  birthはlist/signup/reset/remind resumeを持つ。
+end note
+
 :Healthcheck serverを起動;
 note right
   通常のhealthcheckに加えて
   POST /internal/reminder/scan で
   誕生日未登録リマインドのスキャンを実行できる。
+  POST /internal/birthday/notify で
+  当日の誕生日通知を実行できる。
   POST /interactions で
   Discord Interaction webhookを受信できる。
 end note
-
-:グローバルslash commandをDiscordへ登録;
-:Discord Gateway clientを開始;
 
 stop
 

--- a/docs/uml/整合性チェック.md
+++ b/docs/uml/整合性チェック.md
@@ -9,7 +9,6 @@
   - `src/handler/*`
   - `src/reminder/*`
   - `src/usecase/*`
-  - `src/worker/annual_birthday_notifier.rs`
   - `src/services/healthcheck.rs`
   - `src/data/*`
 - 設計:
@@ -22,9 +21,9 @@
 ## 結果サマリ
 
 - `ER.puml`: 更新済み（誕生日未登録リマインド用カラム、管理者フラグ、リマインド通知先を反映）
-- `初期化処理.puml`: 更新済み（Bot無効時のpassive healthcheck、イベントハンドラ、内部スキャンAPI起動を反映）
+- `初期化処理.puml`: 更新済み（Gateway廃止、RESTでのslash command登録、内部スキャンAPI起動を反映）
 - `birth_コマンド.puml`: 更新済み（サブコマンド化、signup後のリマインドメッセージ削除、remind resumeを反映）
-- `birth_プッシュ通知.puml`: 実装と概ね一致（更新不要）
+- `birth_プッシュ通知.puml`: 更新済み（Cloud Schedulerからの内部API実行を反映）
 - `birth_未登録リマインド.puml`: 新規追加（アクティブ記録、内部スキャン、停止ボタン、管理者セットアップを反映）
 
 ## 補足
@@ -33,5 +32,5 @@
 - `signup` はモーダル送信後に `defer_ephemeral` を実行し、誕生日登録後に保存済みリマインドメッセージ削除を試みる。
 - `signup` と `reset` では、初回参加ユーザー向けに `guild` / `guild_member` のレコードを事前作成する。
 - `Reset` のボタン押下時は、二重応答回避のため先に `Acknowledge` を返す。
-- 誕生日未登録リマインドは、Message / ReactionAdd で `last_active_at` を更新し、`POST /internal/reminder/scan` でも送信候補を走査する。
+- 誕生日未登録リマインドは、`POST /internal/reminder/scan` で送信候補を走査する。
 - `/setup reminder-channel` はDB上の `is_admin` で実行権限を判定する。

--- a/src/data/guild_repository.rs
+++ b/src/data/guild_repository.rs
@@ -1,9 +1,8 @@
 use crate::data::zunda_bot_database::ZundaBotDatabase;
-use crate::models::common::Context;
 use crate::models::data::GuildMember;
 use crate::models::domain::{MyGuild, MyGuildMember};
 use chrono::{DateTime, NaiveDate, Utc};
-use poise::serenity_prelude::{GuildId, Http};
+use serenity::all::{GuildId, Http};
 use sqlx::PgPool;
 use std::sync::Arc;
 
@@ -112,35 +111,12 @@ impl GuildRepository {
         Ok(())
     }
 
-    pub async fn update_last_active(
-        &self,
-        guild_id: i64,
-        member_id: i64,
-        now: DateTime<Utc>,
-        first_remind_at: DateTime<Utc>,
-    ) -> anyhow::Result<()> {
-        self.db
-            .update_member_last_active(guild_id, member_id, now, first_remind_at)
-            .await?;
-        Ok(())
-    }
-
     pub async fn get_active_reminder_candidates(
         &self,
         active_since: DateTime<Utc>,
     ) -> anyhow::Result<Vec<GuildMember>> {
         self.db
             .select_active_reminder_candidates(active_since)
-            .await
-    }
-
-    pub async fn get_active_reminder_candidate(
-        &self,
-        member_id: i64,
-        active_since: DateTime<Utc>,
-    ) -> anyhow::Result<Option<GuildMember>> {
-        self.db
-            .select_active_reminder_candidate_by_member_id(member_id, active_since)
             .await
     }
 
@@ -233,20 +209,6 @@ impl GuildRepository {
             name: partial_guild.name,
             members,
         })
-    }
-
-    pub async fn fetch_guild_id_from_command(
-        &self,
-        poise_ctx: Context<'_>,
-    ) -> anyhow::Result<GuildId> {
-        match poise_ctx.guild_id() {
-            Some(id) => Ok(id),
-            None => {
-                let err_msg = "Could not retrieve the Guild ID.";
-                tracing::error!(err_msg);
-                Err(anyhow::anyhow!(err_msg))
-            }
-        }
     }
 
     pub async fn fetch_my_guild_ids(&self) -> anyhow::Result<Vec<GuildId>> {

--- a/src/data/zunda_bot_database.rs
+++ b/src/data/zunda_bot_database.rs
@@ -238,30 +238,6 @@ impl ZundaBotDatabase {
         Ok(())
     }
 
-    pub async fn update_member_last_active(
-        &self,
-        guild_id: i64,
-        member_id: i64,
-        now: DateTime<Utc>,
-        first_remind_at: DateTime<Utc>,
-    ) -> anyhow::Result<()> {
-        sqlx::query(
-            r#"
-        UPDATE guild_member
-        SET last_active_at = $1,
-            next_remind_at = COALESCE(next_remind_at, $2)
-        WHERE guild_id = $3 AND member_id = $4
-        "#,
-        )
-        .bind(now)
-        .bind(first_remind_at)
-        .bind(guild_id)
-        .bind(member_id)
-        .execute(&*self.pool)
-        .await?;
-        Ok(())
-    }
-
     pub async fn update_member_manual_reminder_target(
         &self,
         guild_id: i64,
@@ -308,37 +284,6 @@ impl ZundaBotDatabase {
         .fetch_all(&*self.pool)
         .await?;
         Ok(rows)
-    }
-
-    pub async fn select_active_reminder_candidate_by_member_id(
-        &self,
-        member_id: i64,
-        active_since: DateTime<Utc>,
-    ) -> anyhow::Result<Option<GuildMember>> {
-        let row = sqlx::query_as::<_, GuildMember>(
-            r#"
-        SELECT
-            guild_id,
-            member_id,
-            birth,
-            last_notified,
-            last_active_at,
-            last_reminded_at,
-            next_remind_at,
-            remind_count,
-            is_remind_opt_out,
-            is_reminder_opted_in
-        FROM guild_member
-        WHERE member_id = $1
-          AND is_reminder_opted_in = TRUE
-          AND last_active_at >= $2
-        "#,
-        )
-        .bind(member_id)
-        .bind(active_since)
-        .fetch_optional(&*self.pool)
-        .await?;
-        Ok(row)
     }
 
     pub async fn update_member_reminder_sent(

--- a/src/handler/interaction.rs
+++ b/src/handler/interaction.rs
@@ -116,18 +116,20 @@ async fn handle_birth_reset_interaction(
         return Ok(true);
     }
 
+    component
+        .create_response(&data.discord_http, CreateInteractionResponse::Acknowledge)
+        .await?;
+
     data.birth_reset_usecase
         .reset_member_birth(guild_id, member_id)
         .await?;
 
     component
-        .create_response(
+        .edit_response(
             &data.discord_http,
-            CreateInteractionResponse::UpdateMessage(
-                CreateInteractionResponseMessage::new()
-                    .content("誕生日の通知登録を解除したのだ。")
-                    .components(Vec::new()),
-            ),
+            EditInteractionResponse::new()
+                .content("誕生日の通知登録を解除したのだ。")
+                .components(Vec::new()),
         )
         .await?;
     Ok(true)

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -1,3 +1,1 @@
 pub mod interaction;
-pub mod message;
-pub mod reaction;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-mod commands;
 mod data;
 mod handler;
 mod models;
@@ -6,25 +5,19 @@ mod reminder;
 mod res;
 mod services;
 mod usecase;
-mod worker;
 
-use crate::commands::birth::birth;
-use crate::commands::setup::setup;
 use crate::models::common::Data;
 use crate::reminder::service::ReminderService;
-use crate::services::healthcheck::{run_healthcheck_server, run_passive_healthcheck_server};
+use crate::services::healthcheck::run_healthcheck_server;
 use crate::usecase::birth_list_usecase::BirthListUsecase;
 use crate::usecase::birth_notify_usecase::BirthNotifyUsecase;
 use crate::usecase::birth_reset_usecase::BirthResetUsecase;
 use crate::usecase::birth_signup_usecase::BirthSignupUsecase;
 use crate::usecase::guild_update_usecase::GuildUpdateUsecase;
-use crate::worker::annual_birthday_notifier::AnnualBirthdayNotifier;
 use anyhow::Context as _;
-use commands::hello::hello;
 use dotenvy::dotenv;
-use poise::serenity_prelude as serenity;
-use serenity::model::gateway::GatewayIntents;
-use serenity::Client;
+use serenity::all::{ChannelType, Command, CommandOptionType, CreateCommand, CreateCommandOption};
+use serenity::http::Http;
 use sqlx::postgres::PgPoolOptions;
 use std::env;
 use std::sync::Arc;
@@ -44,12 +37,6 @@ async fn main() -> anyhow::Result<()> {
         subscriber.with_ansi(false).compact().init();
     }
 
-    if env::var("ENABLE_DISCORD_BOT").context("'ENABLE_DISCORD_BOT' was not found")? == "false" {
-        return run_passive_healthcheck_server()
-            .await
-            .context("Passive healthcheck server stopped");
-    }
-
     let database_url = env::var("DATABASE_URL").context("'DATABASE_URL' was not found")?;
     let pool = PgPoolOptions::new()
         .max_connections(5)
@@ -62,101 +49,109 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let token = env::var("DISCORD_TOKEN").context("'DISCORD_TOKEN' was not found")?;
+    let http = Arc::new(Http::new(&token));
 
-    let intents = GatewayIntents::GUILD_MEMBERS // ギルドメンバー情報取得権限
-        | GatewayIntents::GUILD_MESSAGES // ギルド内のメッセージイベント受信権限
-        | GatewayIntents::GUILD_MESSAGE_REACTIONS // ギルド内のリアクションイベント受信権限
-        | GatewayIntents::DIRECT_MESSAGES
-        | GatewayIntents::MESSAGE_CONTENT;
+    let pool = Arc::new(pool);
+    let birth_list_usecase = BirthListUsecase::new(pool.clone(), http.clone())?;
+    let birth_signup_usecase = BirthSignupUsecase::new(pool.clone(), http.clone())?;
+    let birth_reset_usecase = BirthResetUsecase::new(pool.clone(), http.clone())?;
+    let birth_notify_usecase = BirthNotifyUsecase::new(pool.clone(), http.clone())?;
+    let guild_update_usecase = GuildUpdateUsecase::new(pool.clone(), http.clone())?;
+    let reminder_service = ReminderService::new(pool.clone(), http.clone())?;
 
-    let framework = poise::Framework::builder()
-        .options(poise::FrameworkOptions {
-            commands: vec![
-                // コマンドはここに追加
-                hello(),
-                birth(),
-                setup(),
-            ],
-            event_handler: |ctx, event, _framework, data| {
-                Box::pin(async move {
-                    match event {
-                        serenity::FullEvent::Message { new_message } => {
-                            if let Err(e) =
-                                handler::message::handle_message(ctx, data, new_message).await
-                            {
-                                tracing::warn!("birthday reminder message handler failed: {}", e);
-                            }
-                        }
-                        serenity::FullEvent::ReactionAdd { add_reaction } => {
-                            if let Err(e) =
-                                handler::reaction::handle_reaction_add(ctx, data, add_reaction)
-                                    .await
-                            {
-                                tracing::warn!("birthday reminder reaction handler failed: {}", e);
-                            }
-                        }
-                        serenity::FullEvent::InteractionCreate {
-                            interaction: serenity::Interaction::Component(component),
-                        } => match handler::interaction::handle_component_interaction(
-                            data, component,
-                        )
-                        .await
-                        {
-                            Ok(true) => {}
-                            Ok(false) => {}
-                            Err(e) => tracing::warn!(
-                                "birthday reminder interaction handler failed: {}",
-                                e
-                            ),
-                        },
-                        _ => {}
-                    }
-                    Ok(())
-                })
-            },
-            ..Default::default()
-        })
-        .setup(move |ctx, _ready, framework| {
-            let pool = Arc::new(pool.clone());
-            Box::pin(async move {
-                let birth_list_usecase = BirthListUsecase::new(pool.clone(), ctx.http.clone())?;
-                let birth_signup_usecase = BirthSignupUsecase::new(pool.clone(), ctx.http.clone())?;
-                let birth_reset_usecase = BirthResetUsecase::new(pool.clone(), ctx.http.clone())?;
-                let birth_notify_usecase = BirthNotifyUsecase::new(pool.clone(), ctx.http.clone())?;
-                let guild_update_usecase = GuildUpdateUsecase::new(pool.clone(), ctx.http.clone())?;
-                let reminder_service = ReminderService::new(pool.clone(), ctx.http.clone())?;
-                guild_update_usecase.invoke().await?;
+    guild_update_usecase
+        .invoke()
+        .await
+        .context("Failed to sync guilds on startup")?;
+    register_global_commands(&http).await?;
 
-                tokio::spawn(AnnualBirthdayNotifier::run(birth_notify_usecase));
-
-                poise::builtins::register_globally(ctx, &framework.options().commands).await?;
-
-                let data = Data {
-                    birth_list_usecase,
-                    birth_signup_usecase,
-                    birth_reset_usecase,
-                    guild_update_usecase,
-                    reminder_service,
-                    discord_http: ctx.http.clone(),
-                };
-                let healthcheck_data = data.clone();
-                tokio::spawn(async move {
-                    if let Err(e) = run_healthcheck_server(healthcheck_data).await {
-                        tracing::error!("Healthcheck server stopped: {}", e);
-                    }
-                });
-                Ok(data)
-            })
-        })
-        .build();
-
-    let bot = async {
-        let mut client = Client::builder(&token, intents)
-            .framework(framework)
-            .await?;
-        client.start().await?;
-        Ok::<(), anyhow::Error>(())
+    let data = Data {
+        birth_list_usecase,
+        birth_signup_usecase,
+        birth_reset_usecase,
+        birth_notify_usecase,
+        guild_update_usecase,
+        reminder_service,
+        discord_http: http,
     };
 
-    bot.await.context("Discord bot stopped")
+    run_healthcheck_server(data)
+        .await
+        .context("Healthcheck server stopped")
+}
+
+async fn register_global_commands(http: &Http) -> anyhow::Result<()> {
+    let commands = vec![hello_command(), birth_command(), setup_command()];
+    Command::set_global_commands(http, commands)
+        .await
+        .context("Failed to register global slash commands")?;
+    Ok(())
+}
+
+fn hello_command() -> CreateCommand {
+    CreateCommand::new("hello").description("あいさつを返すのだ")
+}
+
+fn birth_command() -> CreateCommand {
+    CreateCommand::new("birth")
+        .description("誕生日通知を操作するのだ")
+        .add_option(CreateCommandOption::new(
+            CommandOptionType::SubCommand,
+            "list",
+            "誕生日リストを表示するのだ",
+        ))
+        .add_option(CreateCommandOption::new(
+            CommandOptionType::SubCommand,
+            "signup",
+            "自身の誕生日を登録するのだ",
+        ))
+        .add_option(CreateCommandOption::new(
+            CommandOptionType::SubCommand,
+            "reset",
+            "自身の誕生日登録を解除するのだ",
+        ))
+        .add_option(
+            CreateCommandOption::new(
+                CommandOptionType::SubCommandGroup,
+                "remind",
+                "誕生日未登録リマインドを操作するのだ",
+            )
+            .add_sub_option(CreateCommandOption::new(
+                CommandOptionType::SubCommand,
+                "resume",
+                "誕生日未登録リマインドを再開するのだ",
+            )),
+        )
+}
+
+fn setup_command() -> CreateCommand {
+    let channel_option = || {
+        CreateCommandOption::new(CommandOptionType::Channel, "channel", "対象チャンネル")
+            .required(true)
+            .channel_types(vec![ChannelType::Text])
+    };
+
+    CreateCommand::new("setup")
+        .description("管理者向け設定を操作するのだ")
+        .add_option(CreateCommandOption::new(
+            CommandOptionType::SubCommand,
+            "reminder-channel",
+            "誕生日未登録リマインドの送信対象を選ぶのだ",
+        ))
+        .add_option(
+            CreateCommandOption::new(
+                CommandOptionType::SubCommand,
+                "add-notification-channel",
+                "誕生日通知チャンネルを追加するのだ",
+            )
+            .add_sub_option(channel_option()),
+        )
+        .add_option(
+            CreateCommandOption::new(
+                CommandOptionType::SubCommand,
+                "remove-notification-channel",
+                "誕生日通知チャンネルを削除するのだ",
+            )
+            .add_sub_option(channel_option()),
+        )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ mod usecase;
 
 use crate::models::common::Data;
 use crate::reminder::service::ReminderService;
-use crate::services::healthcheck::run_healthcheck_server;
+use crate::services::healthcheck::{new_shared_data, run_healthcheck_server_with_shared_data};
 use crate::usecase::birth_list_usecase::BirthListUsecase;
 use crate::usecase::birth_notify_usecase::BirthNotifyUsecase;
 use crate::usecase::birth_reset_usecase::BirthResetUsecase;
@@ -37,6 +37,34 @@ async fn main() -> anyhow::Result<()> {
         subscriber.with_ansi(false).compact().init();
     }
 
+    let shared_data = new_shared_data();
+    let init_shared_data = shared_data.clone();
+    tokio::spawn(async move {
+        match initialize_data().await {
+            Ok(data) => {
+                match init_shared_data.write() {
+                    Ok(mut guard) => {
+                        *guard = Some(data.clone());
+                    }
+                    Err(_) => {
+                        tracing::error!("shared data lock poisoned before publishing app data");
+                        return;
+                    }
+                }
+                run_startup_tasks(data).await;
+            }
+            Err(e) => {
+                tracing::error!("Application initialization failed: {:?}", e);
+            }
+        }
+    });
+
+    run_healthcheck_server_with_shared_data(shared_data)
+        .await
+        .context("Healthcheck server stopped")
+}
+
+async fn initialize_data() -> anyhow::Result<Data> {
     let database_url = env::var("DATABASE_URL").context("'DATABASE_URL' was not found")?;
     let pool = PgPoolOptions::new()
         .max_connections(5)
@@ -59,13 +87,7 @@ async fn main() -> anyhow::Result<()> {
     let guild_update_usecase = GuildUpdateUsecase::new(pool.clone(), http.clone())?;
     let reminder_service = ReminderService::new(pool.clone(), http.clone())?;
 
-    guild_update_usecase
-        .invoke()
-        .await
-        .context("Failed to sync guilds on startup")?;
-    register_global_commands(&http).await?;
-
-    let data = Data {
+    Ok(Data {
         birth_list_usecase,
         birth_signup_usecase,
         birth_reset_usecase,
@@ -73,11 +95,35 @@ async fn main() -> anyhow::Result<()> {
         guild_update_usecase,
         reminder_service,
         discord_http: http,
-    };
+    })
+}
 
-    run_healthcheck_server(data)
+async fn run_startup_tasks(data: Data) {
+    if let Err(e) = data.guild_update_usecase.invoke().await {
+        tracing::error!("Failed to sync guilds on startup: {:?}", e);
+    }
+
+    if let Err(e) = ensure_application_id(&data.discord_http).await {
+        tracing::error!("Failed to resolve Discord application id: {:?}", e);
+        return;
+    }
+
+    if let Err(e) = register_global_commands(&data.discord_http).await {
+        tracing::error!("Failed to register global slash commands: {:?}", e);
+    }
+}
+
+async fn ensure_application_id(http: &Http) -> anyhow::Result<()> {
+    if http.application_id().is_some() {
+        return Ok(());
+    }
+
+    let application = http
+        .get_current_application_info()
         .await
-        .context("Healthcheck server stopped")
+        .context("Failed to fetch current Discord application info")?;
+    http.set_application_id(application.id);
+    Ok(())
 }
 
 async fn register_global_commands(http: &Http) -> anyhow::Result<()> {

--- a/src/models/common.rs
+++ b/src/models/common.rs
@@ -1,5 +1,6 @@
 use crate::reminder::service::ReminderService;
 use crate::usecase::birth_list_usecase::BirthListUsecase;
+use crate::usecase::birth_notify_usecase::BirthNotifyUsecase;
 use crate::usecase::birth_reset_usecase::BirthResetUsecase;
 use crate::usecase::birth_signup_usecase::BirthSignupUsecase;
 use crate::usecase::guild_update_usecase::GuildUpdateUsecase;
@@ -11,9 +12,8 @@ pub struct Data {
     pub birth_list_usecase: BirthListUsecase,
     pub birth_signup_usecase: BirthSignupUsecase,
     pub birth_reset_usecase: BirthResetUsecase,
+    pub birth_notify_usecase: BirthNotifyUsecase,
     pub guild_update_usecase: GuildUpdateUsecase,
     pub reminder_service: ReminderService,
     pub discord_http: Arc<Http>,
 }
-pub type Error = Box<dyn std::error::Error + Send + Sync>;
-pub type Context<'c> = poise::Context<'c, Data, Error>;

--- a/src/reminder/service.rs
+++ b/src/reminder/service.rs
@@ -4,7 +4,7 @@ use anyhow::Context as _;
 use chrono::{DateTime, Duration, Utc};
 use serenity::all::{
     ButtonStyle, ChannelId, ChannelType, CreateActionRow, CreateButton, CreateChannel,
-    CreateMessage, GuildId, Http, Message, MessageId, Reaction, UserId,
+    CreateMessage, GuildId, Http, MessageId, UserId,
 };
 use sqlx::PgPool;
 use std::collections::{HashMap, HashSet};
@@ -53,66 +53,11 @@ impl ReminderService {
         })
     }
 
-    pub async fn record_message_activity(&self, message: &Message) -> anyhow::Result<()> {
-        if !is_user_activity_recordable(message.author.bot, message.guild_id.is_some()) {
-            return Ok(());
-        }
-
-        let Some(guild_id) = message.guild_id else {
-            return Ok(());
-        };
-        let guild_id = i64::from(guild_id);
-        let member_id = i64::from(message.author.id);
-        self.record_member_activity(guild_id, member_id).await
-    }
-
-    pub async fn record_reaction_activity(&self, reaction: &Reaction) -> anyhow::Result<()> {
-        let user_is_bot = match &reaction.member {
-            Some(member) => member.user.bot,
-            None => reaction.user(&self.http).await?.bot,
-        };
-
-        if !is_user_activity_recordable(user_is_bot, reaction.guild_id.is_some()) {
-            return Ok(());
-        }
-
-        let Some(guild_id) = reaction.guild_id else {
-            return Ok(());
-        };
-        let Some(user_id) = reaction.user_id else {
-            return Ok(());
-        };
-
-        self.record_member_activity(i64::from(guild_id), i64::from(user_id))
-            .await
-    }
-
     async fn ensure_member(&self, guild_id: i64, member_id: i64) -> anyhow::Result<()> {
         self.guild_repo
             .add_guild(guild_id, Some(&format!("guild-{guild_id}")))
             .await?;
         self.guild_repo.add_member(guild_id, member_id, None).await
-    }
-
-    async fn record_member_activity(&self, guild_id: i64, member_id: i64) -> anyhow::Result<()> {
-        let now = Utc::now();
-        let first_remind_at = now + Duration::days(FIRST_REMIND_DELAY_DAYS);
-
-        self.ensure_member(guild_id, member_id).await?;
-        self.guild_repo
-            .update_last_active(guild_id, member_id, now, first_remind_at)
-            .await?;
-
-        let active_since = now - Duration::days(ACTIVE_WINDOW_DAYS);
-        if let Some(user) = self
-            .guild_repo
-            .get_active_reminder_candidate(member_id, active_since)
-            .await?
-        {
-            self.send_due_reminder(&user, now).await?;
-        }
-
-        Ok(())
     }
 
     pub async fn send_due_reminder(&self, user: &User, now: DateTime<Utc>) -> anyhow::Result<bool> {
@@ -509,10 +454,6 @@ fn stagger_delay(user: &User) -> std::time::Duration {
     std::time::Duration::from_secs(seconds)
 }
 
-fn is_user_activity_recordable(user_is_bot: bool, has_guild: bool) -> bool {
-    !user_is_bot && has_guild
-}
-
 async fn fetch_non_bot_display_name(
     http: &Http,
     guild_id: GuildId,
@@ -625,17 +566,6 @@ mod tests {
         user.next_remind_at = None;
 
         assert!(should_show_manual_reminder_candidate(&user, now()));
-    }
-
-    #[test]
-    fn user_activity_is_recordable_for_non_bot_guild_events() {
-        assert!(is_user_activity_recordable(false, true));
-    }
-
-    #[test]
-    fn user_activity_is_not_recordable_for_bots_or_non_guild_events() {
-        assert!(!is_user_activity_recordable(true, true));
-        assert!(!is_user_activity_recordable(false, false));
     }
 
     #[test]

--- a/src/reminder/ui.rs
+++ b/src/reminder/ui.rs
@@ -85,14 +85,6 @@ pub fn parse_reminder_ui_custom_id(custom_id: &str) -> Option<ReminderUiAction> 
     }
 }
 
-pub fn start_components(owner_id: i64, guild_id: i64, session_id: &str) -> Vec<CreateActionRow> {
-    vec![CreateActionRow::Buttons(vec![CreateButton::new(
-        start_button_custom_id(owner_id, guild_id, session_id),
-    )
-    .label("ユーザーを選ぶのだ")
-    .style(ButtonStyle::Primary)])]
-}
-
 pub fn build_selection_content(candidates: &[ReminderUiCandidate], page: usize) -> String {
     if candidates.is_empty() {
         return "誕生日が未登録のユーザーはいないのだ！".to_string();

--- a/src/services/healthcheck.rs
+++ b/src/services/healthcheck.rs
@@ -3,6 +3,7 @@ use crate::services::interaction_webhook::{handle_interaction_body, WebhookHttpR
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use std::env;
 use std::str;
+use std::sync::{Arc, RwLock};
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -10,13 +11,22 @@ use tokio::net::{TcpListener, TcpStream};
 const DISCORD_PUBLIC_KEY_ENV: &str = "DISCORD_PUBLIC_KEY";
 const MAX_REQUEST_BYTES: usize = 64 * 1024;
 
-pub async fn run_healthcheck_server(data: Data) -> anyhow::Result<()> {
-    let port = env::var("PORT").unwrap_or_else(|_| "8080".to_string());
-    let port: u16 = port.parse()?;
-    run_healthcheck_server_on(port, Some(data)).await
+pub type SharedData = Arc<RwLock<Option<Data>>>;
+
+pub fn new_shared_data() -> SharedData {
+    Arc::new(RwLock::new(None))
 }
 
-pub async fn run_healthcheck_server_on(port: u16, data: Option<Data>) -> anyhow::Result<()> {
+pub async fn run_healthcheck_server_with_shared_data(data: SharedData) -> anyhow::Result<()> {
+    let port = env::var("PORT").unwrap_or_else(|_| "8080".to_string());
+    let port: u16 = port.parse()?;
+    run_healthcheck_server_on_shared_data(port, data).await
+}
+
+pub async fn run_healthcheck_server_on_shared_data(
+    port: u16,
+    data: SharedData,
+) -> anyhow::Result<()> {
     let listener = TcpListener::bind(format!("0.0.0.0:{port}")).await?;
     tracing::info!("Healthcheck server listening on 0.0.0.0:{}", port);
 
@@ -36,6 +46,10 @@ pub async fn run_healthcheck_server_on(port: u16, data: Option<Data>) -> anyhow:
 
             let request_head = request_head_for_log(&request);
             tracing::debug!(%request_head, "received healthcheck request");
+            let data = data.read().map(|guard| guard.clone()).unwrap_or_else(|_| {
+                tracing::error!("shared data lock poisoned");
+                None
+            });
             let response = handle_request(&request, data.as_ref()).await;
             tracing::debug!(?response, "healthcheck response");
 
@@ -333,6 +347,18 @@ mod tests {
 
         assert!(response.starts_with("HTTP/1.1 400 Bad Request"));
         assert!(response.ends_with(r#"{"error":"unsupported interaction type"}"#));
+    }
+
+    #[tokio::test]
+    async fn discord_application_command_returns_starting_message_without_data() {
+        let request =
+            signed_interaction_request(r#"{"type":2,"data":{"name":"hello","options":[]}}"#);
+
+        let response = handle_request(request.as_bytes(), None).await;
+
+        assert!(response.starts_with("HTTP/1.1 200 OK"));
+        assert!(response.contains(r#""type":4"#));
+        assert!(response.contains("起動処理中なのだ"));
     }
 
     #[tokio::test]

--- a/src/services/healthcheck.rs
+++ b/src/services/healthcheck.rs
@@ -1,15 +1,18 @@
 use crate::models::common::Data;
 use crate::services::interaction_webhook::{handle_interaction_body, WebhookHttpResponse};
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use serenity::http::Http;
 use std::env;
 use std::str;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, OnceLock, RwLock};
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
 const DISCORD_PUBLIC_KEY_ENV: &str = "DISCORD_PUBLIC_KEY";
+const DISCORD_TOKEN_ENV: &str = "DISCORD_TOKEN";
 const MAX_REQUEST_BYTES: usize = 64 * 1024;
+static DISCORD_PUBLIC_KEY_CACHE: OnceLock<[u8; 32]> = OnceLock::new();
 
 pub type SharedData = Arc<RwLock<Option<Data>>>;
 
@@ -134,7 +137,7 @@ async fn handle_request(request: &[u8], data: Option<&Data>) -> String {
 }
 
 async fn handle_discord_interaction(request: &HttpRequest<'_>, data: Option<&Data>) -> String {
-    if let Err(e) = verify_discord_signature(request) {
+    if let Err(e) = verify_discord_signature(request).await {
         tracing::warn!("Discord interaction signature verification failed: {}", e);
         return json_response(401, r#"{"error":"invalid request signature"}"#);
     }
@@ -150,20 +153,18 @@ async fn handle_discord_interaction(request: &HttpRequest<'_>, data: Option<&Dat
     webhook_response(response)
 }
 
-fn verify_discord_signature(request: &HttpRequest<'_>) -> Result<(), &'static str> {
-    let public_key = env::var(DISCORD_PUBLIC_KEY_ENV)
-        .map_err(|_| "DISCORD_PUBLIC_KEY is not configured")
-        .and_then(|value| decode_fixed_hex::<32>(value.trim()))?;
+async fn verify_discord_signature(request: &HttpRequest<'_>) -> Result<(), String> {
+    let public_key = resolve_discord_public_key().await?;
     let signature = request
         .header("X-Signature-Ed25519")
-        .ok_or("X-Signature-Ed25519 header is missing")
+        .ok_or_else(|| "X-Signature-Ed25519 header is missing".to_string())
         .and_then(decode_fixed_hex::<64>)?;
     let timestamp = request
         .header("X-Signature-Timestamp")
-        .ok_or("X-Signature-Timestamp header is missing")?;
+        .ok_or_else(|| "X-Signature-Timestamp header is missing".to_string())?;
 
     let verifying_key =
-        VerifyingKey::from_bytes(&public_key).map_err(|_| "public key is invalid")?;
+        VerifyingKey::from_bytes(&public_key).map_err(|_| "public key is invalid".to_string())?;
     let signature = Signature::from_bytes(&signature);
     let mut message = Vec::with_capacity(timestamp.len() + request.body.len());
     message.extend_from_slice(timestamp.as_bytes());
@@ -171,12 +172,47 @@ fn verify_discord_signature(request: &HttpRequest<'_>) -> Result<(), &'static st
 
     verifying_key
         .verify(&message, &signature)
-        .map_err(|_| "signature is invalid")
+        .map_err(|_| "signature is invalid".to_string())
 }
 
-fn decode_fixed_hex<const N: usize>(value: &str) -> Result<[u8; N], &'static str> {
+async fn resolve_discord_public_key() -> Result<[u8; 32], String> {
+    if let Some(public_key) = configured_discord_public_key()? {
+        return Ok(public_key);
+    }
+
+    if let Some(public_key) = DISCORD_PUBLIC_KEY_CACHE.get() {
+        return Ok(*public_key);
+    }
+
+    let token = env::var(DISCORD_TOKEN_ENV)
+        .map_err(|_| "DISCORD_PUBLIC_KEY and DISCORD_TOKEN are not configured".to_string())?;
+    let application = Http::new(&token)
+        .get_current_application_info()
+        .await
+        .map_err(|e| format!("failed to fetch Discord application info: {e}"))?;
+    let public_key = decode_fixed_hex::<32>(application.verify_key.trim())?;
+    let _ = DISCORD_PUBLIC_KEY_CACHE.set(public_key);
+    Ok(public_key)
+}
+
+fn configured_discord_public_key() -> Result<Option<[u8; 32]>, String> {
+    match env::var(DISCORD_PUBLIC_KEY_ENV) {
+        Ok(value) => decode_optional_public_key(Some(value.trim())),
+        Err(env::VarError::NotPresent) => Ok(None),
+        Err(env::VarError::NotUnicode(_)) => Err("DISCORD_PUBLIC_KEY is not unicode".to_string()),
+    }
+}
+
+fn decode_optional_public_key(value: Option<&str>) -> Result<Option<[u8; 32]>, String> {
+    value
+        .filter(|value| !value.is_empty())
+        .map(decode_fixed_hex::<32>)
+        .transpose()
+}
+
+fn decode_fixed_hex<const N: usize>(value: &str) -> Result<[u8; N], String> {
     let mut bytes = [0_u8; N];
-    hex::decode_to_slice(value, &mut bytes).map_err(|_| "hex value is invalid")?;
+    hex::decode_to_slice(value, &mut bytes).map_err(|_| "hex value is invalid".to_string())?;
     Ok(bytes)
 }
 
@@ -286,7 +322,8 @@ impl<'a> HttpRequest<'a> {
 #[cfg(test)]
 mod tests {
     use super::{
-        handle_request, json_response, request_is_complete, response_bytes, DISCORD_PUBLIC_KEY_ENV,
+        decode_optional_public_key, handle_request, json_response, request_is_complete,
+        response_bytes, DISCORD_PUBLIC_KEY_ENV,
     };
     use ed25519_dalek::{Signer, SigningKey};
     use std::env;
@@ -315,6 +352,22 @@ mod tests {
 
         assert!(!request_is_complete(partial));
         assert!(request_is_complete(complete));
+    }
+
+    #[test]
+    fn optional_public_key_accepts_missing_and_empty_values() {
+        assert_eq!(decode_optional_public_key(None).unwrap(), None);
+        assert_eq!(decode_optional_public_key(Some("")).unwrap(), None);
+    }
+
+    #[test]
+    fn optional_public_key_decodes_hex_value() {
+        let value = hex::encode([7_u8; 32]);
+
+        assert_eq!(
+            decode_optional_public_key(Some(&value)).unwrap(),
+            Some([7_u8; 32])
+        );
     }
 
     #[tokio::test]

--- a/src/services/healthcheck.rs
+++ b/src/services/healthcheck.rs
@@ -16,12 +16,6 @@ pub async fn run_healthcheck_server(data: Data) -> anyhow::Result<()> {
     run_healthcheck_server_on(port, Some(data)).await
 }
 
-pub async fn run_passive_healthcheck_server() -> anyhow::Result<()> {
-    let port = env::var("PORT").unwrap_or_else(|_| "8080".to_string());
-    let port: u16 = port.parse()?;
-    run_healthcheck_server_on(port, None).await
-}
-
 pub async fn run_healthcheck_server_on(port: u16, data: Option<Data>) -> anyhow::Result<()> {
     let listener = TcpListener::bind(format!("0.0.0.0:{port}")).await?;
     tracing::info!("Healthcheck server listening on 0.0.0.0:{}", port);
@@ -105,6 +99,19 @@ async fn handle_request(request: &[u8], data: Option<&Data>) -> String {
             Err(e) => {
                 tracing::error!("birthday reminder scan failed: {}", e);
                 json_response(500, r#"{"error":"reminder scan failed"}"#)
+            }
+        };
+    }
+
+    if request.method == "POST" && request.path == "/internal/birthday/notify" {
+        let Some(data) = data else {
+            return json_response(503, r#"{"error":"birthday notification disabled"}"#);
+        };
+        return match data.birth_notify_usecase.invoke().await {
+            Ok(()) => json_response(200, r#"{"ok":true}"#),
+            Err(e) => {
+                tracing::error!("birthday notification failed: {}", e);
+                json_response(500, r#"{"error":"birthday notification failed"}"#)
             }
         };
     }
@@ -326,6 +333,16 @@ mod tests {
 
         assert!(response.starts_with("HTTP/1.1 400 Bad Request"));
         assert!(response.ends_with(r#"{"error":"unsupported interaction type"}"#));
+    }
+
+    #[tokio::test]
+    async fn birthday_notify_returns_disabled_without_data() {
+        let request = "POST /internal/birthday/notify HTTP/1.1\r\nContent-Length: 0\r\n\r\n";
+
+        let response = handle_request(request.as_bytes(), None).await;
+
+        assert!(response.starts_with("HTTP/1.1 503 Service Unavailable"));
+        assert!(response.ends_with(r#"{"error":"birthday notification disabled"}"#));
     }
 
     fn signed_interaction_request(body: &str) -> String {

--- a/src/services/interaction_webhook.rs
+++ b/src/services/interaction_webhook.rs
@@ -551,6 +551,7 @@ struct InteractionUser {
 
 #[derive(Debug, Deserialize)]
 struct ApplicationCommandData {
+    #[serde(default)]
     name: String,
     #[serde(default)]
     custom_id: Option<String>,
@@ -677,6 +678,20 @@ mod tests {
         assert_eq!(
             data.modal_text_value(BIRTH_SIGNUP_INPUT_ID),
             Some("02/01".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_component_payload_without_command_name() {
+        let interaction = serde_json::from_str::<DiscordInteraction>(
+            r#"{"type":3,"data":{"custom_id":"birth_reset_confirm:1:2","component_type":2},"member":{"user":{"id":"2"}}}"#,
+        )
+        .expect("component interaction should parse without data.name");
+
+        assert_eq!(interaction.interaction_type, INTERACTION_TYPE_COMPONENT);
+        assert_eq!(
+            interaction.data.and_then(|data| data.custom_id),
+            Some("birth_reset_confirm:1:2".to_string())
         );
     }
 

--- a/src/services/interaction_webhook.rs
+++ b/src/services/interaction_webhook.rs
@@ -8,7 +8,7 @@ use crate::usecase::birth_signup_usecase::BirthSignupResult;
 use anyhow::Context as _;
 use serde::Deserialize;
 use serde_json::{json, Value};
-use serenity::all::{GuildId, Interaction};
+use serenity::all::{ApplicationId, GuildId, Interaction};
 
 const INTERACTION_TYPE_PING: u8 = 1;
 const INTERACTION_TYPE_APPLICATION_COMMAND: u8 = 2;
@@ -16,6 +16,7 @@ const INTERACTION_TYPE_COMPONENT: u8 = 3;
 const INTERACTION_TYPE_MODAL_SUBMIT: u8 = 5;
 const RESPONSE_TYPE_PONG: u8 = 1;
 const RESPONSE_TYPE_CHANNEL_MESSAGE: u8 = 4;
+const RESPONSE_TYPE_DEFERRED_CHANNEL_MESSAGE: u8 = 5;
 const RESPONSE_TYPE_MODAL: u8 = 9;
 const EPHEMERAL_FLAG: u64 = 64;
 const BIRTH_SIGNUP_MODAL_ID: &str = "birth_signup";
@@ -55,15 +56,21 @@ pub async fn handle_interaction_body(
             json!({ "type": RESPONSE_TYPE_PONG }),
         )),
         INTERACTION_TYPE_APPLICATION_COMMAND => {
-            let data = data.context("interaction handler is disabled")?;
+            let Some(data) = data else {
+                return Ok(discord_response(starting_message()));
+            };
             handle_application_command(data, interaction).await
         }
         INTERACTION_TYPE_COMPONENT => {
-            let data = data.context("interaction handler is disabled")?;
+            let Some(data) = data else {
+                return Ok(discord_response(starting_message()));
+            };
             handle_component(data, body).await
         }
         INTERACTION_TYPE_MODAL_SUBMIT => {
-            let data = data.context("interaction handler is disabled")?;
+            let Some(data) = data else {
+                return Ok(discord_response(starting_message()));
+            };
             handle_modal_submit(data, interaction).await
         }
         _ => Ok(WebhookHttpResponse::json(
@@ -77,13 +84,78 @@ async fn handle_application_command(
     data: &Data,
     interaction: DiscordInteraction,
 ) -> anyhow::Result<WebhookHttpResponse> {
+    let command_data = interaction
+        .data
+        .as_ref()
+        .context("application command data missing")?;
+    let route = ApplicationCommandRoute::from_command_data(command_data)
+        .context("unsupported application command")?;
+
+    match route {
+        ApplicationCommandRoute::Hello => Ok(discord_response(message("こんにちは、なのだ!"))),
+        ApplicationCommandRoute::BirthSignup => Ok(discord_response(signup_modal())),
+        route => {
+            let data = data.clone();
+            tokio::spawn(async move {
+                send_deferred_application_command_followup(data, interaction, route).await;
+            });
+            Ok(discord_response(deferred_message()))
+        }
+    }
+}
+
+async fn send_deferred_application_command_followup(
+    data: Data,
+    interaction: DiscordInteraction,
+    route: ApplicationCommandRoute,
+) {
+    let Some(token) = interaction.token.clone() else {
+        tracing::warn!("Discord interaction token missing for deferred followup");
+        return;
+    };
+    let Some(application_id) = interaction
+        .application_id
+        .and_then(|application_id| u64::try_from(application_id).ok())
+    else {
+        tracing::warn!("Discord application id missing for deferred followup");
+        return;
+    };
+    data.discord_http
+        .set_application_id(ApplicationId::new(application_id));
+
+    let followup = match handle_deferred_application_command(&data, interaction, route).await {
+        Ok(response) => match followup_data_from_response(response) {
+            Ok(followup) => followup,
+            Err(e) => {
+                tracing::warn!("Deferred interaction response conversion failed: {}", e);
+                failed_followup_data()
+            }
+        },
+        Err(e) => {
+            tracing::warn!("Deferred interaction handling failed: {}", e);
+            failed_followup_data()
+        }
+    };
+
+    if let Err(e) = data
+        .discord_http
+        .create_followup_message(&token, &followup, Vec::new())
+        .await
+    {
+        tracing::warn!("Discord deferred followup failed: {}", e);
+    }
+}
+
+async fn handle_deferred_application_command(
+    data: &Data,
+    interaction: DiscordInteraction,
+    route: ApplicationCommandRoute,
+) -> anyhow::Result<WebhookHttpResponse> {
     let guild_id = interaction.guild_id;
     let member_id = interaction.user_id();
     let command_data = interaction
         .data
         .context("application command data missing")?;
-    let route = ApplicationCommandRoute::from_command_data(&command_data)
-        .context("unsupported application command")?;
 
     match route {
         ApplicationCommandRoute::Hello => Ok(discord_response(message("こんにちは、なのだ!"))),
@@ -255,6 +327,42 @@ fn message(content: &str) -> Value {
     })
 }
 
+fn starting_message() -> Value {
+    message("起動処理中なのだ。数秒後にもう一度試してほしいのだ。")
+}
+
+fn deferred_message() -> Value {
+    json!({
+        "type": RESPONSE_TYPE_DEFERRED_CHANNEL_MESSAGE,
+        "data": {
+            "flags": EPHEMERAL_FLAG
+        }
+    })
+}
+
+fn failed_followup_data() -> Value {
+    json!({
+        "content": "処理に失敗したのだ。時間をおいて再試行してほしいのだ。",
+        "flags": EPHEMERAL_FLAG
+    })
+}
+
+fn followup_data_from_response(response: WebhookHttpResponse) -> anyhow::Result<Value> {
+    if response.status != 200 {
+        anyhow::bail!("deferred response status was {}", response.status);
+    }
+
+    let body = serde_json::from_str::<Value>(&response.body)
+        .context("deferred response body JSON parse failed")?;
+    if body.get("type").and_then(Value::as_u64) != Some(u64::from(RESPONSE_TYPE_CHANNEL_MESSAGE)) {
+        anyhow::bail!("deferred response was not a channel message");
+    }
+
+    body.get("data")
+        .cloned()
+        .context("deferred response data missing")
+}
+
 fn embed_message(title: &str, color: u32) -> Value {
     json!({
         "type": RESPONSE_TYPE_CHANNEL_MESSAGE,
@@ -411,6 +519,9 @@ struct DiscordInteraction {
     #[serde(rename = "type")]
     interaction_type: u8,
     #[serde(default, deserialize_with = "deserialize_optional_i64")]
+    application_id: Option<i64>,
+    token: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_i64")]
     guild_id: Option<i64>,
     member: Option<InteractionMember>,
     user: Option<InteractionUser>,
@@ -566,6 +677,34 @@ mod tests {
         assert_eq!(
             data.modal_text_value(BIRTH_SIGNUP_INPUT_ID),
             Some("02/01".to_string())
+        );
+    }
+
+    #[test]
+    fn deferred_message_is_ephemeral() {
+        assert_eq!(
+            deferred_message(),
+            json!({
+                "type": 5,
+                "data": {
+                    "flags": 64
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn extracts_followup_data_from_channel_message_response() {
+        let response = discord_response(message("done"));
+
+        let followup = followup_data_from_response(response).expect("followup data should extract");
+
+        assert_eq!(
+            followup,
+            json!({
+                "content": "done",
+                "flags": 64
+            })
         );
     }
 }

--- a/src/usecase/birth_list_usecase.rs
+++ b/src/usecase/birth_list_usecase.rs
@@ -1,10 +1,8 @@
 use crate::data::guild_repository::GuildRepository;
-use crate::models::common::{Context, Error};
 use crate::res::colors::{EMBED_COLOR_SUCCESS, EMBED_COLOR_WARNING};
 use chrono::Datelike;
 use poise::futures_util::future::join_all;
-use poise::CreateReply;
-use serenity::all::{CreateEmbed, GuildId, Http};
+use serenity::all::{GuildId, Http};
 use sqlx::PgPool;
 use std::sync::Arc;
 
@@ -21,19 +19,6 @@ impl BirthListUsecase {
             guild_repo,
             http: http.clone(),
         })
-    }
-
-    pub async fn invoke(&self, poise_ctx: Context<'_>) -> anyhow::Result<(), Error> {
-        // コマンドが実行されたギルドのギルドIDを取得
-        let guild_id = self
-            .guild_repo
-            .fetch_guild_id_from_command(poise_ctx)
-            .await?;
-
-        let view = self.build_view(guild_id).await?;
-        poise_ctx.send(view.into_reply()).await?;
-
-        Ok(())
     }
 
     pub async fn build_view(&self, guild_id: GuildId) -> anyhow::Result<BirthListView> {
@@ -84,26 +69,6 @@ pub enum BirthListView {
 }
 
 impl BirthListView {
-    pub fn into_reply(self) -> CreateReply {
-        match self {
-            Self::Empty => CreateReply::default()
-                .embed(
-                    CreateEmbed::new()
-                        .title("⚠️ 誕生日が登録されていないのだ")
-                        .color(EMBED_COLOR_WARNING),
-                )
-                .ephemeral(true),
-            Self::List { description } => CreateReply::default()
-                .embed(
-                    CreateEmbed::new()
-                        .title("🎉 誕生日リスト")
-                        .description(description)
-                        .color(EMBED_COLOR_SUCCESS),
-                )
-                .ephemeral(true),
-        }
-    }
-
     pub fn title(&self) -> &'static str {
         match self {
             Self::Empty => "⚠️ 誕生日が登録されていないのだ",

--- a/src/usecase/birth_notify_usecase.rs
+++ b/src/usecase/birth_notify_usecase.rs
@@ -1,5 +1,4 @@
 use crate::data::guild_repository::GuildRepository;
-use crate::models::common::Error;
 use crate::models::data::GuildMember;
 use chrono::{Datelike, Local, TimeZone};
 use chrono_tz::Asia::Tokyo;
@@ -10,6 +9,7 @@ use sqlx::PgPool;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+#[derive(Clone)]
 pub struct BirthNotifyUsecase {
     guild_repo: GuildRepository,
     http: Arc<Http>,
@@ -24,7 +24,7 @@ impl BirthNotifyUsecase {
         })
     }
 
-    pub async fn invoke(&self) -> anyhow::Result<(), Error> {
+    pub async fn invoke(&self) -> anyhow::Result<()> {
         let http = &self.http;
         let now = Tokyo.from_utc_datetime(&Local::now().naive_utc());
         let members = self.guild_repo.get_all_members().await?;

--- a/src/usecase/birth_reset_usecase.rs
+++ b/src/usecase/birth_reset_usecase.rs
@@ -1,11 +1,7 @@
 use crate::data::guild_repository::GuildRepository;
-use crate::models::common::{Context, Error};
-use crate::res::colors::{EMBED_COLOR_SUCCESS, EMBED_COLOR_WARNING};
-use poise::CreateReply;
-use serenity::all::{CreateActionRow, CreateButton, CreateEmbed, CreateInteractionResponse, Http};
+use serenity::all::Http;
 use sqlx::PgPool;
 use std::sync::Arc;
-use std::time::Duration;
 
 pub const WEBHOOK_RESET_BUTTON_PREFIX: &str = "birth_reset_confirm";
 
@@ -18,101 +14,6 @@ impl BirthResetUsecase {
     pub fn new(pool: Arc<PgPool>, http: Arc<Http>) -> anyhow::Result<Self> {
         let guild_repo = GuildRepository::new(pool, http.clone())?;
         Ok(BirthResetUsecase { guild_repo })
-    }
-
-    pub async fn invoke(&self, poise_ctx: Context<'_>) -> anyhow::Result<(), Error> {
-        // コマンドが実行されたギルドのギルドIDを取得
-        let guild_id = self
-            .guild_repo
-            .fetch_guild_id_from_command(poise_ctx)
-            .await?;
-        let guild_id = i64::from(guild_id);
-        let guild_name = poise_ctx
-            .guild()
-            .map(|guild| guild.name.clone())
-            .unwrap_or_else(|| format!("guild-{guild_id}"));
-
-        // コマンドを実行したメンバーのメンバーIDを取得
-        let member_id = i64::from(poise_ctx.author().id);
-
-        let view = self
-            .build_confirmation_view(guild_id, Some(guild_name.as_str()), member_id)
-            .await?;
-
-        if !view.has_birth {
-            // 「誕生日が登録されていないこと」をメッセージで通知
-            poise_ctx
-                .send(
-                    CreateReply::default()
-                        .embed(
-                            CreateEmbed::new()
-                                .title("⚠️ 誕生日が登録されていないのだ")
-                                .color(EMBED_COLOR_WARNING), // 警告系の色
-                        )
-                        .ephemeral(true),
-                )
-                .await?;
-        } else {
-            // 誕生日解除の確認メッセージと「解除」ボタンを表示
-            let reset_button = CreateButton::new("reset")
-                .label("解除")
-                .style(serenity::all::ButtonStyle::Danger);
-            let action_row = CreateActionRow::Buttons(vec![reset_button]);
-            let reply_handle = poise_ctx
-                .send(
-                    CreateReply::default()
-                        .content("誕生日の通知登録を解除するのだ⚠️")
-                        .components(vec![action_row])
-                        .ephemeral(true),
-                )
-                .await?;
-            let msg = reply_handle.message().await?;
-
-            let msg_interaction = msg
-                .await_component_interaction(&poise_ctx.serenity_context().shard)
-                .timeout(Duration::from_secs(60))
-                .await;
-            if let Some(interaction) = msg_interaction {
-                if interaction.data.custom_id == "reset" {
-                    interaction
-                        .create_response(poise_ctx.http(), CreateInteractionResponse::Acknowledge)
-                        .await
-                        .unwrap_or_else(|e| {
-                            tracing::warn!("Failed to acknowledge interaction: {}", e)
-                        });
-
-                    // ユーザーが「解除」ボタンを押下
-                    // guild_memberテーブルの誕生日と最終通知日をNULLに更新
-                    self.reset_member_birth(guild_id, member_id).await?;
-
-                    // 誕生日解除の確認メッセージと「解除」ボタンを削除
-                    reply_handle
-                        .delete(poise_ctx)
-                        .await
-                        .unwrap_or_else(|e| tracing::warn!("Failed to delete message: {}", e));
-
-                    // 「誕生日通知が解除されたこと」をメッセージで通知
-                    poise_ctx
-                        .send(
-                            CreateReply::default()
-                                .embed(
-                                    CreateEmbed::new()
-                                        .title("🗑️ 誕生日の通知登録を解除したのだ。")
-                                        .description("登録した日付はリセットされたのだ。")
-                                        .color(EMBED_COLOR_SUCCESS), // 正常系の色
-                                )
-                                .ephemeral(true),
-                        )
-                        .await
-                        .map_err(|e| {
-                            tracing::warn!("Failed to send reset response: {}", e);
-                            e
-                        })
-                        .ok();
-                }
-            }
-        }
-        Ok(())
     }
 
     pub async fn build_confirmation_view(

--- a/src/usecase/birth_signup_usecase.rs
+++ b/src/usecase/birth_signup_usecase.rs
@@ -1,9 +1,7 @@
 use crate::data::guild_repository::GuildRepository;
-use crate::models::common::{Context, Error};
 use crate::res::colors::{EMBED_COLOR_ERROR, EMBED_COLOR_SUCCESS, EMBED_COLOR_WARNING};
 use chrono::NaiveDate;
-use poise::{CreateReply, Modal};
-use serenity::all::{CreateEmbed, Http};
+use serenity::all::Http;
 use sqlx::PgPool;
 use std::sync::Arc;
 
@@ -21,44 +19,6 @@ impl BirthSignupUsecase {
             guild_repo,
             reminder_service,
         })
-    }
-
-    pub async fn invoke(&self, poise_ctx: Context<'_>) -> anyhow::Result<(), Error> {
-        let input_birth = if let Context::Application(app_ctx) = poise_ctx {
-            // 先にモーダルを開いて interaction のタイムアウトを避ける
-            let data = BirthSignupModal::execute(app_ctx).await?;
-            match data {
-                Some(data) => data.birth_input,
-                None => return Ok(()),
-            }
-        } else {
-            return Ok(());
-        };
-
-        // モーダル送信後はインタラクションが一度終了するため、
-        // 以降の応答は defer してから行う必要がある。
-        poise_ctx.defer_ephemeral().await?;
-
-        // コマンドが実行されたギルドのギルドIDを取得
-        let guild_id = self
-            .guild_repo
-            .fetch_guild_id_from_command(poise_ctx)
-            .await?;
-        let guild_id = i64::from(guild_id);
-        let guild_name = poise_ctx
-            .guild()
-            .map(|guild| guild.name.clone())
-            .unwrap_or_else(|| format!("guild-{guild_id}"));
-
-        // コマンドを実行したメンバーのメンバーIDを取得;
-        let member_id = i64::from(poise_ctx.author().id);
-
-        let result = self
-            .register_birth(guild_id, Some(guild_name.as_str()), member_id, &input_birth)
-            .await?;
-        poise_ctx.send(result.into_reply()).await?;
-
-        Ok(())
     }
 
     pub async fn register_birth(
@@ -119,33 +79,6 @@ pub enum BirthSignupResult {
 }
 
 impl BirthSignupResult {
-    pub fn into_reply(self) -> CreateReply {
-        match self {
-            Self::InvalidFormat => CreateReply::default()
-                .embed(
-                    CreateEmbed::new()
-                        .title("🚨  誕生日が正しいフォーマットで入力されていないのだ。")
-                        .color(EMBED_COLOR_ERROR),
-                )
-                .ephemeral(true),
-            Self::Registered => CreateReply::default()
-                .embed(
-                    CreateEmbed::new()
-                        .title("✅  誕生日の通知登録が完了したのだ。")
-                        .color(EMBED_COLOR_SUCCESS),
-                )
-                .content("登録した日付の正午（12:00）に誕生日が通知されるのだ。")
-                .ephemeral(true),
-            Self::AlreadyRegistered => CreateReply::default()
-                .embed(
-                    CreateEmbed::new()
-                        .title("⚠️ 誕生日はすでに登録済みなのだ")
-                        .color(EMBED_COLOR_WARNING),
-                )
-                .ephemeral(true),
-        }
-    }
-
     pub fn title(&self) -> &'static str {
         match self {
             Self::InvalidFormat => "🚨  誕生日が正しいフォーマットで入力されていないのだ。",
@@ -168,14 +101,4 @@ impl BirthSignupResult {
             Self::InvalidFormat | Self::AlreadyRegistered => None,
         }
     }
-}
-
-#[derive(Debug, Modal)]
-#[name = "誕生日の通知登録"] // 最初のタイトル
-struct BirthSignupModal {
-    #[name = "自身の誕生日を入力するのだ"] // フィールドのタイトル
-    #[placeholder = "02/01"]
-    #[min_length = 5]
-    #[max_length = 5]
-    birth_input: String,
 }

--- a/src/usecase/guild_update_usecase.rs
+++ b/src/usecase/guild_update_usecase.rs
@@ -1,5 +1,4 @@
 use crate::data::guild_repository::GuildRepository;
-use crate::models::common::Error;
 use crate::models::data::GuildMember;
 use crate::models::domain::{MyGuild, MyGuildMember};
 use poise::futures_util::future::join_all;
@@ -19,7 +18,7 @@ impl GuildUpdateUsecase {
         Ok(GuildUpdateUsecase { guild_repo })
     }
 
-    pub async fn invoke(&self) -> anyhow::Result<(), Error> {
+    pub async fn invoke(&self) -> anyhow::Result<()> {
         // --- ギルド情報取得  ------------------------------------------------------------------------
         // guildテーブルから「ギルドID」のリストを取得
         let local_guild_ids = self.guild_repo.get_guild_ids().await?;


### PR DESCRIPTION
## 概要

- Discord Gateway client の起動を廃止し、Cloud Run の HTTP webhook 運用へ切り替え
- slash command 登録を Gateway/Poise 起動ではなく Discord REST API 経由に変更
- 当日の誕生日通知を Cloud Scheduler などから `POST /internal/birthday/notify` で実行できるように変更
- `POST /interactions` と `POST /internal/reminder/scan` は継続して利用

Closes #26

## 作業内容

- `src/main.rs` から Gateway intents、Poise framework、Serenity Gateway client、内部誕生日通知ワーカー起動を削除
- `serenity` の直接利用 feature から `client` / `gateway` を外し、REST/webhook に必要な `http` / `model` に整理
- 起動時に `Http::new(DISCORD_TOKEN)` で REST client を作成し、usecase と healthcheck server を初期化
- `Command::set_global_commands` で `hello` / `birth` / `setup` の global slash command を登録
- `POST /internal/birthday/notify` を追加し、`BirthNotifyUsecase::invoke()` を Cloud Scheduler から呼べるように変更
- Gateway event 前提だった message/reaction activity 記録と Poise command 用 invoke/response 変換をコンパイル経路から除去
- README と UML を Gateway 前提から Interactions Endpoint + Cloud Scheduler 前提へ更新
- `/internal/birthday/notify` の routing test を追加

## 作業意図

- Cloud Run では Gateway 常時接続ではなく、Discord Interactions Endpoint URL と内部 HTTP endpoint を入口にするため
- 当日の誕生日通知をプロセス内の 24 時間 loop に依存させず、Cloud Scheduler から明示的に実行できるようにするため
- Gateway intents と message/reaction event handler に依存した起動処理をなくし、Webhook 運用時の責務を `src/services/healthcheck.rs` に集約するため

## 手動で次にするべき作業

- Discord Developer Portal の Interactions Endpoint URL に `https://{{SERVICE_URL}}/interactions` を設定して疎通確認する
- Cloud Scheduler 側で `POST /internal/reminder/scan` と `POST /internal/birthday/notify` を呼ぶジョブを設定または確認する
- 実 Discord 環境で `/hello`, `/birth`, `/setup` 系の webhook 応答を確認する

## 変更ファイル

- `Cargo.toml`
- `README.md`
- `docs/uml/birth_プッシュ通知.puml`
- `docs/uml/birth_未登録リマインド.puml`
- `docs/uml/初期化処理.puml`
- `docs/uml/整合性チェック.md`
- `src/data/guild_repository.rs`
- `src/data/zunda_bot_database.rs`
- `src/handler/mod.rs`
- `src/main.rs`
- `src/models/common.rs`
- `src/reminder/service.rs`
- `src/reminder/ui.rs`
- `src/services/healthcheck.rs`
- `src/usecase/birth_list_usecase.rs`
- `src/usecase/birth_notify_usecase.rs`
- `src/usecase/birth_reset_usecase.rs`
- `src/usecase/birth_signup_usecase.rs`
- `src/usecase/guild_update_usecase.rs`

## テスト結果

- `cargo fmt --check`: 成功
- `cargo clippy --all-targets --all-features -- -D warnings`: 成功
- `cargo test`: 成功（22 passed）

## 制限事項

- 実 Discord webhook endpoint と Cloud Scheduler からの手動疎通確認は未実施
- message create / reaction event の代替機能は Issue #26 の Non-goal のため追加していない
