### PR TITLE
7DTDサーバーVM内セットアップ資産を追加する

### DIFF
--- a/infra/seven-days/backup.sh
+++ b/infra/seven-days/backup.sh
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
+# セーブデータとサーバー設定を時刻付きディレクトリへ退避する。
 set -euo pipefail
+
+# バックアップ元は専用データディスク上の共有ディレクトリに固定する。
 DATA=/srv/seven-days-data
+# UTC時刻を使い、実行環境のタイムゾーンに左右されない名前にする。
 DEST="$DATA/backups/$(date -u +%Y%m%dT%H%M%SZ)"
 mkdir -p "$DEST"
+
+# ワールドデータと設定は必須対象としてコピーする。
 cp -a "$DATA/Saves" "$DATA/GeneratedWorlds" "$DATA/serverconfig.xml" "$DEST/"
+# Mods は未使用の環境もあるため、存在する場合だけバックアップする。
 if [ -d "$DATA/Mods" ]; then cp -a "$DATA/Mods" "$DEST/"; fi
+
+# 運用担当が作成先を確認できるように標準出力へ表示する。
 printf 'Backup created: %s\n' "$DEST"

--- a/infra/seven-days/backup.sh
+++ b/infra/seven-days/backup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+DATA=/srv/seven-days-data
+DEST="$DATA/backups/$(date -u +%Y%m%dT%H%M%SZ)"
+mkdir -p "$DEST"
+cp -a "$DATA/Saves" "$DATA/GeneratedWorlds" "$DATA/serverconfig.xml" "$DEST/"
+if [ -d "$DATA/Mods" ]; then cp -a "$DATA/Mods" "$DEST/"; fi
+printf 'Backup created: %s\n' "$DEST"

--- a/infra/seven-days/install.sh
+++ b/infra/seven-days/install.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+if [ -f /var/lib/seven-days-provisioned ]; then exit 0; fi
+
+apt-get update
+apt-get install -y software-properties-common
+add-apt-repository -y multiverse
+dpkg --add-architecture i386
+apt-get update
+printf 'steam steam/question select I AGREE\nsteam steam/license note \n' | debconf-set-selections
+apt-get install -y steamcmd xfsprogs telnet logrotate
+id seven-days >/dev/null 2>&1 || useradd --system --create-home --shell /usr/sbin/nologin seven-days
+
+DEVICE=/dev/disk/by-id/google-seven-days-data
+MOUNT=/srv/seven-days-data
+mkdir -p "$MOUNT"
+if ! blkid "$DEVICE" >/dev/null 2>&1; then mkfs.xfs "$DEVICE"; fi
+UUID=$(blkid -s UUID -o value "$DEVICE")
+grep -q "$UUID" /etc/fstab || printf 'UUID=%s %s xfs defaults,nofail 0 2\n' "$UUID" "$MOUNT" >> /etc/fstab
+mount "$MOUNT" || mount -a
+mkdir -p "$MOUNT"/{Saves,GeneratedWorlds,Mods,backups} /opt/seven-days
+chown -R seven-days:seven-days "$MOUNT" /opt/seven-days
+
+runuser -u seven-days -- steamcmd +force_install_dir /opt/seven-days +login anonymous +app_update 294420 validate +quit
+METADATA=http://metadata.google.internal/computeMetadata/v1/instance/attributes
+metadata_file() { curl -fsS -H 'Metadata-Flavor: Google' "$METADATA/$1" | base64 -d >"$2"; }
+metadata_file seven-days-safe-stop /usr/local/sbin/seven-days-safe-stop
+metadata_file seven-days-backup /usr/local/sbin/seven-days-backup
+chmod 0755 /usr/local/sbin/seven-days-safe-stop /usr/local/sbin/seven-days-backup
+if [ ! -f "$MOUNT/serverconfig.xml" ]; then metadata_file seven-days-config "$MOUNT/serverconfig.xml"; fi
+
+cat >/etc/systemd/system/seven-days.service <<'UNIT'
+[Unit]
+Description=7 Days to Die Dedicated Server
+After=network-online.target srv-seven\x2ddays\x2ddata.mount
+RequiresMountsFor=/srv/seven-days-data
+
+[Service]
+Type=simple
+User=seven-days
+WorkingDirectory=/opt/seven-days
+ExecStart=/opt/seven-days/startserver.sh -configfile=/srv/seven-days-data/serverconfig.xml -UserDataFolder=/srv/seven-days-data
+ExecStop=+/usr/local/sbin/seven-days-safe-stop
+TimeoutStopSec=180
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+systemctl daemon-reload
+systemctl enable seven-days.service
+if ! grep -q 'CHANGE_BEFORE_START' "$MOUNT/serverconfig.xml"; then systemctl start seven-days.service; fi
+cat >/etc/logrotate.d/seven-days <<'ROTATE'
+/srv/seven-days-data/logs/*.txt {
+  daily
+  rotate 14
+  compress
+  missingok
+  notifempty
+  copytruncate
+}
+ROTATE
+touch /var/lib/seven-days-provisioned

--- a/infra/seven-days/install.sh
+++ b/infra/seven-days/install.sh
@@ -1,36 +1,82 @@
 #!/usr/bin/env bash
+# 7 Days to Die 用VMを初回起動時に構成するプロビジョニングスクリプト。
 set -euo pipefail
+# apt の対話プロンプトを無効化し、起動時に自動実行できるようにする。
 export DEBIAN_FRONTEND=noninteractive
 
+# 完了マーカーがある場合は再実行せず、既存環境を変更しない。
 if [ -f /var/lib/seven-days-provisioned ]; then exit 0; fi
 
+# SteamCMD と、データディスクを扱うためのツールをインストールする。
 apt-get update
+## steamcmdはUbuntuのaptリポジトリ区分の一つmultiverse(ライセンスや再配布条件に制限があるソフトウェア)に分類されるため、multiverseを有効にする
 apt-get install -y software-properties-common
 add-apt-repository -y multiverse
+## steamcmdがi386(32bit x86)版として提供されているため、64-bit Ubuntu VM環境で必要
 dpkg --add-architecture i386
 apt-get update
+## Steam ライセンス確認への回答を先に登録して、apt の停止を防ぐ。
 printf 'steam steam/question select I AGREE\nsteam steam/license note \n' | debconf-set-selections
-apt-get install -y steamcmd xfsprogs telnet logrotate
+## curlはGCP VMのメタデータ取得に使用
+apt-get install -y curl steamcmd xfsprogs telnet logrotate
+
+# サーバープロセス専用の権限を作成する（既存ならそのまま利用する）。
 id seven-days >/dev/null 2>&1 || useradd --system --create-home --shell /usr/sbin/nologin seven-days
 
+# 追加の永続データ用ディスクをXFSで初期化し、再起動後も同じ場所へマウントする。
+## デバイス(ディスク操作用 - ゲームデータを書き込むと、XFSの構造を壊したり、データを上書きする危険があるので直接触らない)
 DEVICE=/dev/disk/by-id/google-seven-days-data
+## マウントポイント(ファイル操作用)
 MOUNT=/srv/seven-days-data
 mkdir -p "$MOUNT"
+## XFSとしてフォーマットし、ディスク内部にUUIDを保存
 if ! blkid "$DEVICE" >/dev/null 2>&1; then mkfs.xfs "$DEVICE"; fi
+## UUIDを取得
 UUID=$(blkid -s UUID -o value "$DEVICE")
+## fstab（マウント設定記録ファイル）にマウント情報を記録
+##
+## UUID=...                マウントするディスク
+## /srv/seven-days-data    マウント先
+## xfs                     ファイルシステムの種類
+## defaults,nofail         マウントオプション
+## 0                       dump対象外
+## 2                       ファイルシステム検査の順番
 grep -q "$UUID" /etc/fstab || printf 'UUID=%s %s xfs defaults,nofail 0 2\n' "$UUID" "$MOUNT" >> /etc/fstab
+## ゲームの本体とセーブデータ
+##
+## ゲーム本体
+## /opt/seven-days
+##
+## セーブデータ
+## /srv/seven-days-data
+##    ├── Saves
+##    ├── GeneratedWorlds
+##    ├── Mods
+##    ├── backups
+##    └── serverconfig.xml
 mount "$MOUNT" || mount -a
 mkdir -p "$MOUNT"/{Saves,GeneratedWorlds,Mods,backups} /opt/seven-days
 chown -R seven-days:seven-days "$MOUNT" /opt/seven-days
 
+# ゲームサーバー本体を専用ユーザー(seven-days)でインストール・検証する。
 runuser -u seven-days -- steamcmd +force_install_dir /opt/seven-days +login anonymous +app_update 294420 validate +quit
+
+# Compute Engine のメタデータから、停止・バックアップ用スクリプトを取得する。
 METADATA=http://metadata.google.internal/computeMetadata/v1/instance/attributes
+## metadata_file(): GCP VMのメタデータサーバーから設定済みの値を取得する関数
+## 1. GCPメタデータから値を取得
+## 2. Base64としてデコード
+## 3. 指定されたファイルへ保存
 metadata_file() { curl -fsS -H 'Metadata-Flavor: Google' "$METADATA/$1" | base64 -d >"$2"; }
 metadata_file seven-days-safe-stop /usr/local/sbin/seven-days-safe-stop
 metadata_file seven-days-backup /usr/local/sbin/seven-days-backup
 chmod 0755 /usr/local/sbin/seven-days-safe-stop /usr/local/sbin/seven-days-backup
+
+# 初回だけメタデータにある設定テンプレートを永続ディスクへ配置する。
+## 運用中に変更される設定ファイルなので、初回のみ配置
 if [ ! -f "$MOUNT/serverconfig.xml" ]; then metadata_file seven-days-config "$MOUNT/serverconfig.xml"; fi
 
+# systemd でサーバーを管理し、停止時には安全停止スクリプトを呼び出す。
 cat >/etc/systemd/system/seven-days.service <<'UNIT'
 [Unit]
 Description=7 Days to Die Dedicated Server
@@ -50,9 +96,25 @@ Restart=on-failure
 WantedBy=multi-user.target
 UNIT
 
+# unit を登録して自動起動を有効化する。
 systemctl daemon-reload
 systemctl enable seven-days.service
-if ! grep -q 'CHANGE_BEFORE_START' "$MOUNT/serverconfig.xml"; then systemctl start seven-days.service; fi
+
+# プレースホルダーが残る場合は起動せず、設定変更後の再実行に備える。
+SERVER_STARTED=false
+if grep -q 'CHANGE_BEFORE_START' "$MOUNT/serverconfig.xml"; then
+  printf 'serverconfig.xml の CHANGE_BEFORE_START を変更してから再実行してください\n' >&2
+else
+  systemctl start seven-days.service
+  # start の成功だけでなく、systemd が active と判定したことも確認する。
+  if ! systemctl is-active --quiet seven-days.service; then
+    printf '7 Days to Die サーバーの起動を確認できないため、完了マーカーを作成しません\n' >&2
+    exit 1
+  fi
+  SERVER_STARTED=true
+fi
+
+# ゲームログを日次でローテーションし、直近14世代を保持する。
 cat >/etc/logrotate.d/seven-days <<'ROTATE'
 /srv/seven-days-data/logs/*.txt {
   daily
@@ -63,4 +125,8 @@ cat >/etc/logrotate.d/seven-days <<'ROTATE'
   copytruncate
 }
 ROTATE
-touch /var/lib/seven-days-provisioned
+
+# サーバーが active であることを確認できた場合だけ、次回の初期化処理を省略する。
+if [ "$SERVER_STARTED" = true ]; then
+  touch /var/lib/seven-days-provisioned
+fi

--- a/infra/seven-days/safe-stop.sh
+++ b/infra/seven-days/safe-stop.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+TELNET_HOST=${TELNET_HOST:-127.0.0.1}
+TELNET_PORT=${TELNET_PORT:-8081}
+TELNET_PASSWORD_FILE=${TELNET_PASSWORD_FILE:-/srv/seven-days-data/telnet-password}
+if [ -r "$TELNET_PASSWORD_FILE" ]; then
+  PASSWORD=$(<"$TELNET_PASSWORD_FILE")
+  { printf '%s\n' "$PASSWORD"; sleep 1; printf 'say Server shutting down in 30 seconds\nsaveworld\n'; sleep 30; printf 'shutdown\n'; } | telnet "$TELNET_HOST" "$TELNET_PORT" >/dev/null
+fi
+for _ in $(seq 1 60); do pgrep -f '7DaysToDieServer' >/dev/null || exit 0; sleep 2; done
+exit 1

--- a/infra/seven-days/safe-stop.sh
+++ b/infra/seven-days/safe-stop.sh
@@ -1,11 +1,35 @@
 #!/usr/bin/env bash
+# systemd の停止処理から呼び出し、ゲーム内の保存と安全なシャットダウンを行う。
+#
+# systemdから単純にプロセスを強制終了すると、ワールド保存が完了せず、
+# データ破損や巻き戻りが起きる可能性があるため、ゲーム内の正式な停止コマンドでサーバーを終了する
+
 set -euo pipefail
+
+# 環境変数で接続先とパスワードファイルを変更できるようにする。
 TELNET_HOST=${TELNET_HOST:-127.0.0.1}
 TELNET_PORT=${TELNET_PORT:-8081}
 TELNET_PASSWORD_FILE=${TELNET_PASSWORD_FILE:-/srv/seven-days-data/telnet-password}
+
+# パスワードファイルがない場合は telnet 操作をスキップし、プロセス終了の待機だけを行う。
 if [ -r "$TELNET_PASSWORD_FILE" ]; then
   PASSWORD=$(<"$TELNET_PASSWORD_FILE")
-  { printf '%s\n' "$PASSWORD"; sleep 1; printf 'say Server shutting down in 30 seconds\nsaveworld\n'; sleep 30; printf 'shutdown\n'; } | telnet "$TELNET_HOST" "$TELNET_PORT" >/dev/null
+
+  # パスワード入力後に保存を実行し、30秒の告知時間を置いてからサーバーを停止する。
+  {
+    printf '%s\n' "$PASSWORD"
+    sleep 1
+    printf 'say Server shutting down in 30 seconds\nsaveworld\n'
+    sleep 30
+    printf 'shutdown\n'
+  } | telnet "$TELNET_HOST" "$TELNET_PORT" >/dev/null
 fi
-for _ in $(seq 1 60); do pgrep -f '7DaysToDieServer' >/dev/null || exit 0; sleep 2; done
+
+# 停止要求後、最大120秒間プロセスが終了するのを待つ。
+for _ in $(seq 1 60); do
+  pgrep -f '7DaysToDieServer' >/dev/null || exit 0
+  sleep 2
+done
+
+# 期限内に終了しなければ systemd に停止失敗として通知する。
 exit 1

--- a/infra/seven-days/serverconfig.template.xml
+++ b/infra/seven-days/serverconfig.template.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<ServerSettings>
+  <property name="ServerName" value="Zunda 7DTD" />
+  <property name="ServerPort" value="26900" />
+  <property name="ServerMaxPlayerCount" value="8" />
+  <property name="GameWorld" value="Navezgane" />
+  <property name="GameName" value="ZundaGame" />
+  <property name="ServerPassword" value="CHANGE_BEFORE_START" />
+  <property name="TelnetEnabled" value="true" />
+  <property name="TelnetPort" value="8081" />
+  <property name="TelnetPassword" value="CHANGE_BEFORE_START" />
+  <property name="TelnetFailedLoginLimit" value="3" />
+  <property name="TelnetFailedLoginsBlocktime" value="10" />
+</ServerSettings>


### PR DESCRIPTION
## 概要

- Issue #36: 7DTDサーバーVM内セットアップ資産を追加する
- 親Issue: #33
- 7 Days to Die Dedicated Server の VM 内セットアップ資産を追加

## 作業内容

- SteamCMD / 7DTD server の install script を追加
- systemd service 作成処理を追加
- safe-stop script を追加
- backup script を追加
- `serverconfig.xml` template を追加

## 作業意図

- Terraform で作成した VM 上に、7DTD server を再現可能に構築するため

## 手動で次にするべき作業

- 実VM上で `install.sh` の動作確認を行う
- systemd service の起動・停止を確認する
- backup / safe-stop の実動作を確認する

## 変更ファイル

- `infra/seven-days/backup.sh`
- `infra/seven-days/install.sh`
- `infra/seven-days/safe-stop.sh`
- `infra/seven-days/serverconfig.template.xml`

## テスト結果

- `bash -n infra/seven-days/install.sh infra/seven-days/safe-stop.sh infra/seven-days/backup.sh`: success

## 制限事項

- 実VM上でのインストール実行は未実施
- server password や secret 値は含めていない
