### PR TITLE
Discord /7dtdでVMを安全に起動・確認・停止できるようにする

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ ed25519-dalek = "2.1.1"
 hex = "0.4.3"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
+reqwest = { version = "0.12.22", default-features = false, features = ["json", "rustls-tls"] }

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ gcloud run services describe zunda-bot-rs \
 
 ## 7 Days to Die サーバー
 
-許可された Discord Guild／Channel／User・Role から `/7dtd start`、`/7dtd status`、管理者の `/7dtd stop` を実行できる。GCP 構築、Cloud Run 環境変数、セーブ移行、安全停止、backup／復元は Runbook を参照する。
+許可された Discord Guild／Channel／User・Role から `/7dtd status`、管理者から `/7dtd start` と `/7dtd stop` を実行できる。GCP 構築、Cloud Run 環境変数、セーブ移行、安全停止、backup／復元は Runbook を参照する。
 READY までの非同期処理を確実に完了させるため、初期構成では Runbook 記載の Cloud Run CPU 設定が必要になる。
 
 ## デバッグ

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ gcloud run services describe zunda-bot-rs \
 
 ## 7 Days to Die サーバー
 
-許可された Discord Guild／Channel／User・Role から `/7dtd status`、管理者から `/7dtd start` と `/7dtd stop` を実行できる。GCP 構築、Cloud Run 環境変数、セーブ移行、安全停止、backup／復元は Runbook を参照する。
+許可された Discord Guild／Channel／User・Role から `/7dtd status`、管理者から `/7dtd start` と `/7dtd stop` を実行できる。開始・停止はPostgreSQLのトランザクションロックで排他し、別の処理中はVM操作を実行せず使用中メッセージを返す。GCP 構築、Cloud Run 環境変数、セーブ移行、安全停止、backup／復元は Runbook を参照する。
 READY までの非同期処理を確実に完了させるため、初期構成では Runbook 記載の Cloud Run CPU 設定が必要になる。
 
 ## デバッグ

--- a/docs/seven-days-server.md
+++ b/docs/seven-days-server.md
@@ -19,7 +19,7 @@ SEVEN_DAYS_DISCORD_USER_IDS, SEVEN_DAYS_DISCORD_ROLE_IDS
 SEVEN_DAYS_DISCORD_ADMIN_USER_IDS, SEVEN_DAYS_DISCORD_ADMIN_ROLE_IDS
 ```
 
-ID のリストはカンマ区切り。一般 ID は start/status、管理 ID は start/status/stop を実行できる。
+ID のリストはカンマ区切り。一般 ID は status、管理 ID は start/status/stop を実行できる。
 
 ゲームサーバーは身内の 2〜4 人だけで利用する。`game_source_ranges` には参加者の固定 IPv4 を `/32` で指定し、ゲーム用ポートへの接続元を限定する。VPN は利用しない。自宅回線の IP が変わった場合は、Terraform の値を更新して再 apply する。SSH などの管理用ポートを全世界へ公開しない。
 
@@ -34,9 +34,9 @@ ID のリストはカンマ区切り。一般 ID は start/status、管理 ID �
 
 ## 通常運用と障害対応
 
-- `/7dtd start`: TERMINATED の場合だけ起動し、外部 IPv4 を DuckDNS に登録して TCP 26900 が開くまで待つ。
+- `/7dtd start`: 管理者限定。TERMINATED の場合だけ起動し、外部 IPv4 を DuckDNS に登録して TCP 26900 が開くまで待つ。
 - `/7dtd status`: VM、ポート、domain、外部 IPv4、稼働時間を表示する。
-- `/7dtd stop`: Compute Engine の通常停止を要求する。systemd `ExecStop` がゲーム内通知、`saveworld`、`shutdown`、プロセス終了確認を行う。停止完了は status で確認する。
+- `/7dtd stop`: 管理者限定。Compute Engine の通常停止を要求する。systemd `ExecStop` がゲーム内通知、`saveworld`、`shutdown`、プロセス終了確認を行う。停止完了は status で確認する。
 - READY にならない場合は serial/startup logs、`systemctl status seven-days`、`journalctl -u seven-days`、firewall、`serverconfig.xml` を確認する。
 - DuckDNS 失敗時は Secret の version と Cloud Run service account の accessor IAM を確認する。token を URL やログに貼らない。
 - stop が完了しない場合は VM を強制停止せず journal と telnet password file を確認し、ゲーム内で保存後に再試行する。

--- a/docs/seven-days-server.md
+++ b/docs/seven-days-server.md
@@ -37,6 +37,7 @@ ID のリストはカンマ区切り。一般 ID は status、管理 ID は star
 - `/7dtd start`: 管理者限定。TERMINATED の場合だけ起動し、外部 IPv4 を DuckDNS に登録して TCP 26900 が開くまで待つ。
 - `/7dtd status`: VM、ポート、domain、外部 IPv4、稼働時間を表示する。
 - `/7dtd stop`: 管理者限定。Compute Engine の通常停止を要求する。systemd `ExecStop` がゲーム内通知、`saveworld`、`shutdown`、プロセス終了確認を行う。停止完了は status で確認する。
+- `/7dtd start` と `/7dtd stop` はPostgreSQLのトランザクションロックを取得してからVM操作を行う。別の開始・停止処理が実行中ならVM APIを呼ばず使用中メッセージを返す。Cloud Runが複数インスタンスでも同じDBロックを共有する。
 - READY にならない場合は serial/startup logs、`systemctl status seven-days`、`journalctl -u seven-days`、firewall、`serverconfig.xml` を確認する。
 - DuckDNS 失敗時は Secret の version と Cloud Run service account の accessor IAM を確認する。token を URL やログに貼らない。
 - stop が完了しない場合は VM を強制停止せず journal と telnet password file を確認し、ゲーム内で保存後に再試行する。

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use crate::usecase::birth_notify_usecase::BirthNotifyUsecase;
 use crate::usecase::birth_reset_usecase::BirthResetUsecase;
 use crate::usecase::birth_signup_usecase::BirthSignupUsecase;
 use crate::usecase::guild_update_usecase::GuildUpdateUsecase;
+use crate::usecase::seven_days_usecase::SevenDaysUsecase;
 use anyhow::Context as _;
 use dotenvy::dotenv;
 use serenity::all::{ChannelType, Command, CommandOptionType, CreateCommand, CreateCommandOption};
@@ -95,6 +96,7 @@ async fn initialize_data() -> anyhow::Result<Data> {
         guild_update_usecase,
         reminder_service,
         discord_http: http,
+        seven_days_usecase: SevenDaysUsecase::from_env()?,
     })
 }
 
@@ -127,11 +129,36 @@ async fn ensure_application_id(http: &Http) -> anyhow::Result<()> {
 }
 
 async fn register_global_commands(http: &Http) -> anyhow::Result<()> {
-    let commands = vec![hello_command(), birth_command(), setup_command()];
+    let commands = vec![
+        hello_command(),
+        birth_command(),
+        setup_command(),
+        seven_days_command(),
+    ];
     Command::set_global_commands(http, commands)
         .await
         .context("Failed to register global slash commands")?;
     Ok(())
+}
+
+fn seven_days_command() -> CreateCommand {
+    CreateCommand::new("7dtd")
+        .description("7 Days to Die 専用サーバーを操作するのだ")
+        .add_option(CreateCommandOption::new(
+            CommandOptionType::SubCommand,
+            "start",
+            "サーバーを起動するのだ",
+        ))
+        .add_option(CreateCommandOption::new(
+            CommandOptionType::SubCommand,
+            "status",
+            "サーバーの状態を確認するのだ",
+        ))
+        .add_option(CreateCommandOption::new(
+            CommandOptionType::SubCommand,
+            "stop",
+            "サーバーを安全に停止するのだ",
+        ))
 }
 
 fn hello_command() -> CreateCommand {

--- a/src/main.rs
+++ b/src/main.rs
@@ -96,7 +96,7 @@ async fn initialize_data() -> anyhow::Result<Data> {
         guild_update_usecase,
         reminder_service,
         discord_http: http,
-        seven_days_usecase: SevenDaysUsecase::from_env()?,
+        seven_days_usecase: SevenDaysUsecase::from_env(pool)?,
     })
 }
 

--- a/src/models/common.rs
+++ b/src/models/common.rs
@@ -4,6 +4,7 @@ use crate::usecase::birth_notify_usecase::BirthNotifyUsecase;
 use crate::usecase::birth_reset_usecase::BirthResetUsecase;
 use crate::usecase::birth_signup_usecase::BirthSignupUsecase;
 use crate::usecase::guild_update_usecase::GuildUpdateUsecase;
+use crate::usecase::seven_days_usecase::SevenDaysUsecase;
 use serenity::all::Http;
 use std::sync::Arc;
 
@@ -16,4 +17,5 @@ pub struct Data {
     pub guild_update_usecase: GuildUpdateUsecase,
     pub reminder_service: ReminderService,
     pub discord_http: Arc<Http>,
+    pub seven_days_usecase: Option<SevenDaysUsecase>,
 }

--- a/src/services/interaction_webhook.rs
+++ b/src/services/interaction_webhook.rs
@@ -254,6 +254,24 @@ async fn handle_deferred_application_command(
                     "このコマンドを実行する権限がないのだ。",
                 )));
             }
+            let _operation_lock = if requires_operation_lock(route) {
+                match usecase.try_operation_lock().await {
+                    Ok(Some(lock)) => Some(lock),
+                    Ok(None) => {
+                        return Ok(discord_response(message(
+                            "7DTD サーバーは現在、別の開始または停止処理中なのだ。完了してからもう一度試してほしいのだ。",
+                        )))
+                    }
+                    Err(error) => {
+                        tracing::error!(error = %error, "7DTD operation lock failed");
+                        return Ok(discord_response(message(
+                            "7DTD サーバーの操作受付を確認できないのだ。少し待ってから再試行してほしいのだ。",
+                        )))
+                    }
+                }
+            } else {
+                None
+            };
             tracing::info!(?guild_id, ?channel_id, user_id = ?member_id, command = ?route, "starting 7DTD command");
             let result = match route {
                 ApplicationCommandRoute::SevenDaysStart => usecase.start().await,
@@ -373,6 +391,13 @@ fn message(content: &str) -> Value {
             "flags": EPHEMERAL_FLAG
         }
     })
+}
+
+fn requires_operation_lock(route: ApplicationCommandRoute) -> bool {
+    matches!(
+        route,
+        ApplicationCommandRoute::SevenDaysStart | ApplicationCommandRoute::SevenDaysStop
+    )
 }
 
 fn starting_message() -> Value {
@@ -755,6 +780,19 @@ mod tests {
         assert!(ApplicationCommandRoute::SevenDaysStart.requires_seven_days_admin());
         assert!(ApplicationCommandRoute::SevenDaysStop.requires_seven_days_admin());
         assert!(!ApplicationCommandRoute::SevenDaysStatus.requires_seven_days_admin());
+    }
+
+    #[test]
+    fn only_start_and_stop_take_the_operation_lock() {
+        assert!(requires_operation_lock(
+            ApplicationCommandRoute::SevenDaysStart
+        ));
+        assert!(requires_operation_lock(
+            ApplicationCommandRoute::SevenDaysStop
+        ));
+        assert!(!requires_operation_lock(
+            ApplicationCommandRoute::SevenDaysStatus
+        ));
     }
 
     #[test]

--- a/src/services/interaction_webhook.rs
+++ b/src/services/interaction_webhook.rs
@@ -247,7 +247,7 @@ async fn handle_deferred_application_command(
                 user_id: member_id,
                 role_ids: &role_ids,
             };
-            let admin = route == ApplicationCommandRoute::SevenDaysStop;
+            let admin = route.requires_seven_days_admin();
             if !usecase.authorize(&caller, admin) {
                 tracing::warn!(?guild_id, ?channel_id, user_id = ?member_id, command = ?route, "unauthorized 7DTD command");
                 return Ok(discord_response(message(
@@ -541,6 +541,10 @@ pub enum ApplicationCommandRoute {
 }
 
 impl ApplicationCommandRoute {
+    fn requires_seven_days_admin(self) -> bool {
+        matches!(self, Self::SevenDaysStart | Self::SevenDaysStop)
+    }
+
     fn from_command_data(data: &ApplicationCommandData) -> Option<Self> {
         match data.name.as_str() {
             "hello" => Some(Self::Hello),
@@ -744,6 +748,13 @@ mod tests {
                 Some(expected)
             );
         }
+    }
+
+    #[test]
+    fn starting_and_stopping_seven_days_require_admin() {
+        assert!(ApplicationCommandRoute::SevenDaysStart.requires_seven_days_admin());
+        assert!(ApplicationCommandRoute::SevenDaysStop.requires_seven_days_admin());
+        assert!(!ApplicationCommandRoute::SevenDaysStatus.requires_seven_days_admin());
     }
 
     #[test]

--- a/src/services/interaction_webhook.rs
+++ b/src/services/interaction_webhook.rs
@@ -730,12 +730,20 @@ mod tests {
     }
 
     #[test]
-    fn routes_seven_days_stop_command() {
-        let data = command_data(r#"{"type":2,"data":{"name":"7dtd","options":[{"name":"stop"}]}}"#);
-        assert_eq!(
-            ApplicationCommandRoute::from_command_data(&data),
-            Some(ApplicationCommandRoute::SevenDaysStop)
-        );
+    fn routes_seven_days_commands() {
+        for (subcommand, expected) in [
+            ("start", ApplicationCommandRoute::SevenDaysStart),
+            ("status", ApplicationCommandRoute::SevenDaysStatus),
+            ("stop", ApplicationCommandRoute::SevenDaysStop),
+        ] {
+            let data = command_data(&format!(
+                r#"{{"type":2,"data":{{"name":"7dtd","options":[{{"name":"{subcommand}"}}]}}}}"#
+            ));
+            assert_eq!(
+                ApplicationCommandRoute::from_command_data(&data),
+                Some(expected)
+            );
+        }
     }
 
     #[test]

--- a/src/services/interaction_webhook.rs
+++ b/src/services/interaction_webhook.rs
@@ -5,6 +5,7 @@ use crate::res::colors::EMBED_COLOR_WARNING;
 use crate::usecase::birth_list_usecase::BirthListView;
 use crate::usecase::birth_reset_usecase::webhook_reset_button_custom_id;
 use crate::usecase::birth_signup_usecase::BirthSignupResult;
+use crate::usecase::seven_days_usecase::Caller;
 use anyhow::Context as _;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -152,7 +153,13 @@ async fn handle_deferred_application_command(
     route: ApplicationCommandRoute,
 ) -> anyhow::Result<WebhookHttpResponse> {
     let guild_id = interaction.guild_id;
+    let channel_id = interaction.channel_id;
     let member_id = interaction.user_id();
+    let role_ids = interaction
+        .member
+        .as_ref()
+        .map(|member| member.roles.clone())
+        .unwrap_or_default();
     let command_data = interaction
         .data
         .context("application command data missing")?;
@@ -225,6 +232,47 @@ async fn handle_deferred_application_command(
         }
         ApplicationCommandRoute::SetupRemoveNotificationChannel => {
             manage_notification_channel(data, guild_id, member_id, &command_data, false).await
+        }
+        ApplicationCommandRoute::SevenDaysStart
+        | ApplicationCommandRoute::SevenDaysStatus
+        | ApplicationCommandRoute::SevenDaysStop => {
+            let Some(usecase) = &data.seven_days_usecase else {
+                return Ok(discord_response(message(
+                    "7DTD サーバーは設定されていないのだ。",
+                )));
+            };
+            let caller = Caller {
+                guild_id,
+                channel_id,
+                user_id: member_id,
+                role_ids: &role_ids,
+            };
+            let admin = route == ApplicationCommandRoute::SevenDaysStop;
+            if !usecase.authorize(&caller, admin) {
+                tracing::warn!(?guild_id, ?channel_id, user_id = ?member_id, command = ?route, "unauthorized 7DTD command");
+                return Ok(discord_response(message(
+                    "このコマンドを実行する権限がないのだ。",
+                )));
+            }
+            tracing::info!(?guild_id, ?channel_id, user_id = ?member_id, command = ?route, "starting 7DTD command");
+            let result = match route {
+                ApplicationCommandRoute::SevenDaysStart => usecase.start().await,
+                ApplicationCommandRoute::SevenDaysStatus => usecase.status().await,
+                ApplicationCommandRoute::SevenDaysStop => usecase.stop().await,
+                _ => unreachable!(),
+            };
+            match result {
+                Ok(content) => {
+                    tracing::info!(command = ?route, "7DTD command completed");
+                    Ok(discord_response(message(&content)))
+                }
+                Err(error) => {
+                    tracing::error!(command = ?route, error = %error, "7DTD command failed");
+                    Ok(discord_response(message(
+                        "7DTD サーバーの操作に失敗したのだ。管理者にログ確認を依頼してほしいのだ。",
+                    )))
+                }
+            }
         }
     }
 }
@@ -477,7 +525,7 @@ fn value_as_i64(value: &Value) -> Option<i64> {
         .or_else(|| value.as_str()?.parse::<i64>().ok())
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ApplicationCommandRoute {
     Hello,
     BirthList,
@@ -487,6 +535,9 @@ pub enum ApplicationCommandRoute {
     SetupReminderChannel,
     SetupAddNotificationChannel,
     SetupRemoveNotificationChannel,
+    SevenDaysStart,
+    SevenDaysStatus,
+    SevenDaysStop,
 }
 
 impl ApplicationCommandRoute {
@@ -509,6 +560,12 @@ impl ApplicationCommandRoute {
                 "remove-notification-channel" => Some(Self::SetupRemoveNotificationChannel),
                 _ => None,
             },
+            "7dtd" => match data.options.first()?.name.as_str() {
+                "start" => Some(Self::SevenDaysStart),
+                "status" => Some(Self::SevenDaysStatus),
+                "stop" => Some(Self::SevenDaysStop),
+                _ => None,
+            },
             _ => None,
         }
     }
@@ -523,6 +580,8 @@ struct DiscordInteraction {
     token: Option<String>,
     #[serde(default, deserialize_with = "deserialize_optional_i64")]
     guild_id: Option<i64>,
+    #[serde(default, deserialize_with = "deserialize_optional_i64")]
+    channel_id: Option<i64>,
     member: Option<InteractionMember>,
     user: Option<InteractionUser>,
     data: Option<ApplicationCommandData>,
@@ -541,6 +600,8 @@ impl DiscordInteraction {
 #[derive(Debug, Deserialize)]
 struct InteractionMember {
     user: Option<InteractionUser>,
+    #[serde(default, deserialize_with = "deserialize_i64_vec")]
+    roles: Vec<i64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -623,6 +684,18 @@ where
     value_as_i64(&value).ok_or_else(|| serde::de::Error::custom("invalid integer value"))
 }
 
+fn deserialize_i64_vec<'de, D>(deserializer: D) -> Result<Vec<i64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Vec::<Value>::deserialize(deserializer)?
+        .iter()
+        .map(|value| {
+            value_as_i64(value).ok_or_else(|| serde::de::Error::custom("invalid integer value"))
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -653,6 +726,15 @@ mod tests {
         assert_eq!(
             ApplicationCommandRoute::from_command_data(&data),
             Some(ApplicationCommandRoute::BirthRemindResume)
+        );
+    }
+
+    #[test]
+    fn routes_seven_days_stop_command() {
+        let data = command_data(r#"{"type":2,"data":{"name":"7dtd","options":[{"name":"stop"}]}}"#);
+        assert_eq!(
+            ApplicationCommandRoute::from_command_data(&data),
+            Some(ApplicationCommandRoute::SevenDaysStop)
         );
     }
 

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,3 +1,4 @@
 pub mod healthcheck;
 pub mod interaction_webhook;
 pub mod seven_days_gcp;
+pub mod seven_days_operation_lock;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,2 +1,3 @@
 pub mod healthcheck;
 pub mod interaction_webhook;
+pub mod seven_days_gcp;

--- a/src/services/seven_days_gcp.rs
+++ b/src/services/seven_days_gcp.rs
@@ -147,13 +147,20 @@ impl DuckDnsClient {
                 ("ip", ip),
             ])
             .send()
-            .await?
-            .error_for_status()?
+            .await
+            .map_err(redact_request_url)?
+            .error_for_status()
+            .map_err(redact_request_url)?
             .text()
-            .await?;
+            .await
+            .map_err(redact_request_url)?;
         anyhow::ensure!(response.trim() == "OK", "DuckDNS update was rejected");
         Ok(())
     }
+}
+
+fn redact_request_url(error: reqwest::Error) -> anyhow::Error {
+    anyhow::Error::new(error.without_url())
 }
 
 #[cfg(test)]

--- a/src/services/seven_days_gcp.rs
+++ b/src/services/seven_days_gcp.rs
@@ -1,0 +1,178 @@
+use anyhow::{Context as _, Result};
+use reqwest::{Client, StatusCode};
+use serde::Deserialize;
+use std::time::Duration;
+
+const METADATA_TOKEN_URL: &str =
+    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
+
+#[derive(Clone)]
+pub struct ComputeClient {
+    http: Client,
+    project: String,
+    zone: String,
+    instance: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstanceStatus {
+    pub state: String,
+    pub external_ip: Option<String>,
+    pub last_start: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct AccessToken {
+    access_token: String,
+}
+
+#[derive(Deserialize)]
+struct InstanceResponse {
+    status: String,
+    #[serde(rename = "lastStartTimestamp")]
+    last_start_timestamp: Option<String>,
+    #[serde(default)]
+    network_interfaces: Vec<NetworkInterface>,
+}
+
+#[derive(Deserialize)]
+struct NetworkInterface {
+    #[serde(default)]
+    access_configs: Vec<AccessConfig>,
+}
+
+#[derive(Deserialize)]
+struct AccessConfig {
+    #[serde(rename = "natIP")]
+    nat_i_p: Option<String>,
+}
+
+impl ComputeClient {
+    pub fn new(project: String, zone: String, instance: String) -> Result<Self> {
+        let http = Client::builder().timeout(Duration::from_secs(15)).build()?;
+        Ok(Self {
+            http,
+            project,
+            zone,
+            instance,
+        })
+    }
+
+    async fn token(&self) -> Result<String> {
+        Ok(self
+            .http
+            .get(METADATA_TOKEN_URL)
+            .header("Metadata-Flavor", "Google")
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<AccessToken>()
+            .await?
+            .access_token)
+    }
+
+    fn instance_url(&self) -> String {
+        format!(
+            "https://compute.googleapis.com/compute/v1/projects/{}/zones/{}/instances/{}",
+            self.project, self.zone, self.instance
+        )
+    }
+
+    pub async fn status(&self) -> Result<InstanceStatus> {
+        let response = self
+            .http
+            .get(self.instance_url())
+            .bearer_auth(self.token().await?)
+            .send()
+            .await?
+            .error_for_status()
+            .context("Compute Engine instance lookup failed")?
+            .json::<InstanceResponse>()
+            .await?;
+        let external_ip = response
+            .network_interfaces
+            .first()
+            .and_then(|interface| interface.access_configs.first())
+            .and_then(|config| config.nat_i_p.clone());
+        Ok(InstanceStatus {
+            state: response.status,
+            external_ip,
+            last_start: response.last_start_timestamp,
+        })
+    }
+
+    pub async fn start(&self) -> Result<()> {
+        self.action("start").await
+    }
+    pub async fn stop(&self) -> Result<()> {
+        self.action("stop").await
+    }
+
+    async fn action(&self, action: &str) -> Result<()> {
+        let response = self
+            .http
+            .post(format!("{}/{}", self.instance_url(), action))
+            .bearer_auth(self.token().await?)
+            .send()
+            .await?;
+        if response.status() != StatusCode::OK {
+            response.error_for_status()?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct DuckDnsClient {
+    http: Client,
+    domain: String,
+    token: String,
+}
+
+impl DuckDnsClient {
+    pub fn new(domain: String, token: String) -> Self {
+        Self {
+            http: Client::new(),
+            domain,
+            token,
+        }
+    }
+    pub async fn update(&self, ip: &str) -> Result<()> {
+        let response = self
+            .http
+            .get("https://www.duckdns.org/update")
+            .query(&[
+                ("domains", self.domain.as_str()),
+                ("token", self.token.as_str()),
+                ("ip", ip),
+            ])
+            .send()
+            .await?
+            .error_for_status()?
+            .text()
+            .await?;
+        anyhow::ensure!(response.trim() == "OK", "DuckDNS update was rejected");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_compute_external_ipv4() {
+        let response: InstanceResponse = serde_json::from_str(
+            r#"{"status":"RUNNING","lastStartTimestamp":"2026-01-01T00:00:00Z","network_interfaces":[{"access_configs":[{"natIP":"203.0.113.10"}]}]}"#,
+        )
+        .expect("Compute response should parse");
+
+        assert_eq!(response.status, "RUNNING");
+        assert_eq!(
+            response.network_interfaces[0].access_configs[0]
+                .nat_i_p
+                .as_deref(),
+            Some("203.0.113.10")
+        );
+    }
+}

--- a/src/services/seven_days_operation_lock.rs
+++ b/src/services/seven_days_operation_lock.rs
@@ -1,0 +1,39 @@
+use anyhow::{Context as _, Result};
+use sqlx::{Postgres, Transaction};
+use std::time::Duration;
+
+const LOCK_KEY: i64 = 7_071_007;
+const LOCK_ACQUIRE_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// 7DTDの開始・停止をCloud Runの複数インスタンス間で直列化するトランザクションロック。
+/// guardがdropされると未commit transactionがrollbackされ、ロックも解放される。
+pub struct SevenDaysOperationLock {
+    transaction: Option<Transaction<'static, Postgres>>,
+}
+
+impl SevenDaysOperationLock {
+    pub async fn try_acquire(pool: &sqlx::PgPool) -> Result<Option<Self>> {
+        let transaction = match tokio::time::timeout(LOCK_ACQUIRE_TIMEOUT, pool.begin()).await {
+            Ok(transaction) => transaction.context("7DTD operation lock transaction failed")?,
+            Err(_) => return Ok(None),
+        };
+        let mut transaction = transaction;
+        let acquired: bool = sqlx::query_scalar("SELECT pg_try_advisory_xact_lock($1)")
+            .bind(LOCK_KEY)
+            .fetch_one(&mut *transaction)
+            .await
+            .context("7DTD operation lock query failed")?;
+        if !acquired {
+            return Ok(None);
+        }
+        Ok(Some(Self {
+            transaction: Some(transaction),
+        }))
+    }
+}
+
+impl Drop for SevenDaysOperationLock {
+    fn drop(&mut self) {
+        let _ = self.transaction.take();
+    }
+}

--- a/src/usecase/mod.rs
+++ b/src/usecase/mod.rs
@@ -3,3 +3,4 @@ pub mod birth_notify_usecase;
 pub mod birth_reset_usecase;
 pub mod birth_signup_usecase;
 pub mod guild_update_usecase;
+pub mod seven_days_usecase;

--- a/src/usecase/seven_days_usecase.rs
+++ b/src/usecase/seven_days_usecase.rs
@@ -1,7 +1,9 @@
 use crate::services::seven_days_gcp::{ComputeClient, DuckDnsClient, InstanceStatus};
+use crate::services::seven_days_operation_lock::SevenDaysOperationLock;
 use anyhow::{Context as _, Result};
 use chrono::{DateTime, Utc};
-use std::{collections::HashSet, env, time::Duration};
+use sqlx::PgPool;
+use std::{collections::HashSet, env, sync::Arc, time::Duration};
 use tokio::net::TcpStream;
 use tokio::time::Instant;
 
@@ -15,6 +17,7 @@ pub struct SevenDaysUsecase {
     domain: String,
     port: u16,
     auth: Authorization,
+    operation_pool: Arc<PgPool>,
 }
 
 #[derive(Clone)]
@@ -54,7 +57,7 @@ pub struct Caller<'a> {
 }
 
 impl SevenDaysUsecase {
-    pub fn from_env() -> Result<Option<Self>> {
+    pub fn from_env(operation_pool: Arc<PgPool>) -> Result<Option<Self>> {
         let Some(project) = optional_env("SEVEN_DAYS_GCP_PROJECT") else {
             return Ok(None);
         };
@@ -82,7 +85,12 @@ impl SevenDaysUsecase {
                 admin_users: id_set("SEVEN_DAYS_DISCORD_ADMIN_USER_IDS")?,
                 admin_roles: id_set("SEVEN_DAYS_DISCORD_ADMIN_ROLE_IDS")?,
             },
+            operation_pool,
         }))
+    }
+
+    pub async fn try_operation_lock(&self) -> Result<Option<SevenDaysOperationLock>> {
+        SevenDaysOperationLock::try_acquire(&self.operation_pool).await
     }
 
     pub fn authorize(&self, caller: &Caller<'_>, admin: bool) -> bool {

--- a/src/usecase/seven_days_usecase.rs
+++ b/src/usecase/seven_days_usecase.rs
@@ -3,6 +3,10 @@ use anyhow::{Context as _, Result};
 use chrono::{DateTime, Utc};
 use std::{collections::HashSet, env, time::Duration};
 use tokio::net::TcpStream;
+use tokio::time::Instant;
+
+const START_TIMEOUT: Duration = Duration::from_secs(10 * 60);
+const POLL_INTERVAL: Duration = Duration::from_secs(5);
 
 #[derive(Clone)]
 pub struct SevenDaysUsecase {
@@ -58,14 +62,14 @@ impl SevenDaysUsecase {
             env::var(name).with_context(|| format!("'{name}' is required when 7DTD is enabled"))
         };
         let parse = |name: &str| -> Result<i64> { Ok(required(name)?.parse()?) };
-        let domain = required("SEVEN_DAYS_DUCKDNS_DOMAIN")?;
+        let (duckdns_subdomain, domain) = duckdns_names(&required("SEVEN_DAYS_DUCKDNS_DOMAIN")?)?;
         Ok(Some(Self {
             compute: ComputeClient::new(
                 project,
                 required("SEVEN_DAYS_GCP_ZONE")?,
                 required("SEVEN_DAYS_GCP_INSTANCE")?,
             )?,
-            duckdns: DuckDnsClient::new(domain.clone(), required("SEVEN_DAYS_DUCKDNS_TOKEN")?),
+            duckdns: DuckDnsClient::new(duckdns_subdomain, required("SEVEN_DAYS_DUCKDNS_TOKEN")?),
             domain,
             port: optional_env("SEVEN_DAYS_PORT")
                 .unwrap_or_else(|| "26900".into())
@@ -86,6 +90,7 @@ impl SevenDaysUsecase {
     }
 
     pub async fn start(&self) -> Result<String> {
+        let deadline = Instant::now() + START_TIMEOUT;
         let mut status = self.compute.status().await?;
         if status.state == "TERMINATED" {
             self.compute.start().await?;
@@ -95,41 +100,38 @@ impl SevenDaysUsecase {
                 status.state
             ));
         }
-        for _ in 0..30 {
+        while Instant::now() < deadline {
             status = self.compute.status().await?;
             if status.state == "RUNNING" && status.external_ip.is_some() {
                 break;
             }
-            tokio::time::sleep(Duration::from_secs(5)).await;
+            tokio::time::sleep(POLL_INTERVAL).await;
         }
         let ip = status
             .external_ip
             .context("VM started but external IPv4 was unavailable")?;
         self.duckdns.update(&ip).await?;
-        for _ in 0..30 {
+        while Instant::now() < deadline {
             if tcp_ready(&ip, self.port).await {
                 return Ok(format!(
                     "READY なのだ！ `{}` / `{}:{}`",
                     self.domain, ip, self.port
                 ));
             }
-            tokio::time::sleep(Duration::from_secs(5)).await;
+            tokio::time::sleep(POLL_INTERVAL).await;
         }
         anyhow::bail!("VM and DuckDNS are ready, but the game port did not become reachable")
     }
 
     pub async fn status(&self) -> Result<String> {
         let status = self.compute.status().await?;
+        let uptime = uptime_minutes(&status, Utc::now())
+            .map(|minutes| format!("{minutes}分"))
+            .unwrap_or_else(|| "なし".into());
         let ip = status.external_ip.unwrap_or_else(|| "なし".into());
         let ready = status.state == "RUNNING" && tcp_ready(&ip, self.port).await;
-        let uptime = status
-            .last_start
-            .as_deref()
-            .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
-            .map(|started| (Utc::now() - started.with_timezone(&Utc)).num_minutes())
-            .unwrap_or(0);
         Ok(format!(
-            "VM: {}\nゲーム: {}\n接続先: `{}:{}`\n外部 IPv4: `{}`\n稼働時間: {}分",
+            "VM: {}\nゲーム: {}\n接続先: `{}:{}`\n外部 IPv4: `{}`\n稼働時間: {}",
             status.state,
             if ready { "READY" } else { "NOT READY" },
             self.domain,
@@ -171,6 +173,35 @@ fn id_set(name: &str) -> Result<HashSet<i64>> {
         .collect()
 }
 
+fn duckdns_names(value: &str) -> Result<(String, String)> {
+    let value = value.trim().trim_end_matches('.').to_ascii_lowercase();
+    let subdomain = value.strip_suffix(".duckdns.org").unwrap_or(&value);
+    anyhow::ensure!(
+        !subdomain.is_empty() && !subdomain.contains('.'),
+        "SEVEN_DAYS_DUCKDNS_DOMAIN must be a DuckDNS subdomain or FQDN"
+    );
+    anyhow::ensure!(
+        subdomain
+            .chars()
+            .all(|character| character.is_ascii_lowercase()
+                || character.is_ascii_digit()
+                || character == '-'),
+        "SEVEN_DAYS_DUCKDNS_DOMAIN contains invalid characters"
+    );
+    Ok((subdomain.into(), format!("{subdomain}.duckdns.org")))
+}
+
+fn uptime_minutes(status: &InstanceStatus, now: DateTime<Utc>) -> Option<i64> {
+    if status.state != "RUNNING" {
+        return None;
+    }
+    status
+        .last_start
+        .as_deref()
+        .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+        .map(|started| (now - started.with_timezone(&Utc)).num_minutes().max(0))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -207,5 +238,37 @@ mod tests {
         };
         assert!(auth().allowed(&admin, true));
         assert!(auth().allowed(&admin, false));
+    }
+
+    #[test]
+    fn normalizes_duckdns_subdomain_and_fqdn() {
+        assert_eq!(
+            duckdns_names("Zunda-7DTD.duckdns.org.").expect("domain should be valid"),
+            ("zunda-7dtd".into(), "zunda-7dtd.duckdns.org".into())
+        );
+        assert_eq!(
+            duckdns_names("zunda-7dtd").expect("subdomain should be valid"),
+            ("zunda-7dtd".into(), "zunda-7dtd.duckdns.org".into())
+        );
+        assert!(duckdns_names("example.com").is_err());
+    }
+
+    #[test]
+    fn uptime_is_only_reported_for_running_instance() {
+        let now = DateTime::parse_from_rfc3339("2026-08-12T03:00:00Z")
+            .expect("timestamp should parse")
+            .with_timezone(&Utc);
+        let running = InstanceStatus {
+            state: "RUNNING".into(),
+            external_ip: None,
+            last_start: Some("2026-08-12T01:30:00Z".into()),
+        };
+        assert_eq!(uptime_minutes(&running, now), Some(90));
+
+        let stopped = InstanceStatus {
+            state: "TERMINATED".into(),
+            ..running
+        };
+        assert_eq!(uptime_minutes(&stopped, now), None);
     }
 }

--- a/src/usecase/seven_days_usecase.rs
+++ b/src/usecase/seven_days_usecase.rs
@@ -1,0 +1,211 @@
+use crate::services::seven_days_gcp::{ComputeClient, DuckDnsClient, InstanceStatus};
+use anyhow::{Context as _, Result};
+use chrono::{DateTime, Utc};
+use std::{collections::HashSet, env, time::Duration};
+use tokio::net::TcpStream;
+
+#[derive(Clone)]
+pub struct SevenDaysUsecase {
+    compute: ComputeClient,
+    duckdns: DuckDnsClient,
+    domain: String,
+    port: u16,
+    auth: Authorization,
+}
+
+#[derive(Clone)]
+struct Authorization {
+    guild_id: i64,
+    channel_id: i64,
+    users: HashSet<i64>,
+    roles: HashSet<i64>,
+    admin_users: HashSet<i64>,
+    admin_roles: HashSet<i64>,
+}
+
+impl Authorization {
+    fn allowed(&self, caller: &Caller<'_>, admin: bool) -> bool {
+        if caller.guild_id != Some(self.guild_id) || caller.channel_id != Some(self.channel_id) {
+            return false;
+        }
+        let Some(user) = caller.user_id else {
+            return false;
+        };
+        let base = self.users.contains(&user)
+            || caller.role_ids.iter().any(|role| self.roles.contains(role));
+        let elevated = self.admin_users.contains(&user)
+            || caller
+                .role_ids
+                .iter()
+                .any(|role| self.admin_roles.contains(role));
+        elevated || (!admin && base)
+    }
+}
+
+pub struct Caller<'a> {
+    pub guild_id: Option<i64>,
+    pub channel_id: Option<i64>,
+    pub user_id: Option<i64>,
+    pub role_ids: &'a [i64],
+}
+
+impl SevenDaysUsecase {
+    pub fn from_env() -> Result<Option<Self>> {
+        let Some(project) = optional_env("SEVEN_DAYS_GCP_PROJECT") else {
+            return Ok(None);
+        };
+        let required = |name: &str| {
+            env::var(name).with_context(|| format!("'{name}' is required when 7DTD is enabled"))
+        };
+        let parse = |name: &str| -> Result<i64> { Ok(required(name)?.parse()?) };
+        let domain = required("SEVEN_DAYS_DUCKDNS_DOMAIN")?;
+        Ok(Some(Self {
+            compute: ComputeClient::new(
+                project,
+                required("SEVEN_DAYS_GCP_ZONE")?,
+                required("SEVEN_DAYS_GCP_INSTANCE")?,
+            )?,
+            duckdns: DuckDnsClient::new(domain.clone(), required("SEVEN_DAYS_DUCKDNS_TOKEN")?),
+            domain,
+            port: optional_env("SEVEN_DAYS_PORT")
+                .unwrap_or_else(|| "26900".into())
+                .parse()?,
+            auth: Authorization {
+                guild_id: parse("SEVEN_DAYS_DISCORD_GUILD_ID")?,
+                channel_id: parse("SEVEN_DAYS_DISCORD_CHANNEL_ID")?,
+                users: id_set("SEVEN_DAYS_DISCORD_USER_IDS")?,
+                roles: id_set("SEVEN_DAYS_DISCORD_ROLE_IDS")?,
+                admin_users: id_set("SEVEN_DAYS_DISCORD_ADMIN_USER_IDS")?,
+                admin_roles: id_set("SEVEN_DAYS_DISCORD_ADMIN_ROLE_IDS")?,
+            },
+        }))
+    }
+
+    pub fn authorize(&self, caller: &Caller<'_>, admin: bool) -> bool {
+        self.auth.allowed(caller, admin)
+    }
+
+    pub async fn start(&self) -> Result<String> {
+        let mut status = self.compute.status().await?;
+        if status.state == "TERMINATED" {
+            self.compute.start().await?;
+        } else if status.state != "RUNNING" {
+            return Ok(format!(
+                "VM は現在 {} なのだ。起動処理の完了を待ってほしいのだ。",
+                status.state
+            ));
+        }
+        for _ in 0..30 {
+            status = self.compute.status().await?;
+            if status.state == "RUNNING" && status.external_ip.is_some() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        }
+        let ip = status
+            .external_ip
+            .context("VM started but external IPv4 was unavailable")?;
+        self.duckdns.update(&ip).await?;
+        for _ in 0..30 {
+            if tcp_ready(&ip, self.port).await {
+                return Ok(format!(
+                    "READY なのだ！ `{}` / `{}:{}`",
+                    self.domain, ip, self.port
+                ));
+            }
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        }
+        anyhow::bail!("VM and DuckDNS are ready, but the game port did not become reachable")
+    }
+
+    pub async fn status(&self) -> Result<String> {
+        let status = self.compute.status().await?;
+        let ip = status.external_ip.unwrap_or_else(|| "なし".into());
+        let ready = status.state == "RUNNING" && tcp_ready(&ip, self.port).await;
+        let uptime = status
+            .last_start
+            .as_deref()
+            .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+            .map(|started| (Utc::now() - started.with_timezone(&Utc)).num_minutes())
+            .unwrap_or(0);
+        Ok(format!(
+            "VM: {}\nゲーム: {}\n接続先: `{}:{}`\n外部 IPv4: `{}`\n稼働時間: {}分",
+            status.state,
+            if ready { "READY" } else { "NOT READY" },
+            self.domain,
+            self.port,
+            ip,
+            uptime
+        ))
+    }
+
+    pub async fn stop(&self) -> Result<String> {
+        let InstanceStatus { state, .. } = self.compute.status().await?;
+        if state == "TERMINATED" {
+            return Ok("VM はすでに停止しているのだ。".into());
+        }
+        anyhow::ensure!(
+            state == "RUNNING",
+            "VM is {state}; refusing a duplicate stop request"
+        );
+        self.compute.stop().await?;
+        Ok("安全停止を要求したのだ。systemd がワールド保存と正常終了を行ってから VM を停止するのだ。".into())
+    }
+}
+
+async fn tcp_ready(ip: &str, port: u16) -> bool {
+    tokio::time::timeout(Duration::from_secs(2), TcpStream::connect((ip, port)))
+        .await
+        .map(|r| r.is_ok())
+        .unwrap_or(false)
+}
+fn optional_env(name: &str) -> Option<String> {
+    env::var(name).ok().filter(|v| !v.trim().is_empty())
+}
+fn id_set(name: &str) -> Result<HashSet<i64>> {
+    optional_env(name)
+        .unwrap_or_default()
+        .split(',')
+        .filter(|v| !v.trim().is_empty())
+        .map(|v| v.trim().parse().map_err(Into::into))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn auth() -> Authorization {
+        Authorization {
+            guild_id: 1,
+            channel_id: 2,
+            users: HashSet::from([3]),
+            roles: HashSet::from([4]),
+            admin_users: HashSet::from([5]),
+            admin_roles: HashSet::from([6]),
+        }
+    }
+    #[test]
+    fn authorization_requires_location_and_id() {
+        let caller = Caller {
+            guild_id: Some(1),
+            channel_id: Some(2),
+            user_id: Some(3),
+            role_ids: &[],
+        };
+        assert!(auth().allowed(&caller, false));
+        assert!(!auth().allowed(&caller, true));
+        let wrong_channel = Caller {
+            channel_id: Some(9),
+            ..caller
+        };
+        assert!(!auth().allowed(&wrong_channel, false));
+        let admin = Caller {
+            guild_id: Some(1),
+            channel_id: Some(2),
+            user_id: Some(5),
+            role_ids: &[],
+        };
+        assert!(auth().allowed(&admin, true));
+        assert!(auth().allowed(&admin, false));
+    }
+}


### PR DESCRIPTION
## 概要

- Issue #38: Discord `/7dtd` コマンドでGCP上の専用サーバーを操作できるようにする
- Discord interaction webhook 経由で `/7dtd start`、`status`、`stop` を扱う
- 開始・停止を管理者限定、状態確認を一般許可ユーザーにも許可する
- 後続のVM運用仕様を踏まえ、起動待機・DuckDNS・稼働時間表示を安全化

## 作業内容

- `/7dtd` command の webhook dispatch とglobal command登録を追加
- Compute Engine API の状態確認・起動・停止serviceを追加
- DuckDNS更新処理を追加し、エラーからtokenを含むURLを除去
- DuckDNS subdomain/FQDNを正規化
- start/status/stop usecaseとGuild／Channel／Role／User ID権限制御を追加
- `/7dtd start`と`/7dtd stop`を管理者ID・Role限定に設定
- 起動待機をVMとゲームポートを合わせた10分上限へ変更
- 停止中に過去の起動時刻から稼働時間を加算し続けないよう修正
- `/7dtd` 3サブコマンドのdispatch・管理者要否テストを追加

## 作業意図

- Cloud Run上のBotから必要なときだけ7DTD VMを操作するため
- 課金とワールド状態を変更する開始・停止を管理者だけに限定するため
- Issue #36 / PR #42で確定した最大10分のゲームポート待受仕様へBot側を近づけるため
- DuckDNS tokenがHTTPエラー経由でログへ含まれないようにするため

## 手動で次にするべき作業

- #43 のREADY通知・安全停止追随PRを先に確認する
- 一般許可ユーザーで`/7dtd status`だけ成功し、`start`と`stop`が拒否されることを確認する
- 管理者で`/7dtd start`、`status`、`stop`を確認する
- DuckDNS更新後のdomainと外部IPv4を確認する

## 変更ファイル

- `Cargo.toml`
- `README.md`
- `docs/seven-days-server.md`
- `src/main.rs`
- `src/models/common.rs`
- `src/services/interaction_webhook.rs`
- `src/services/mod.rs`
- `src/services/seven_days_gcp.rs`
- `src/usecase/mod.rs`
- `src/usecase/seven_days_usecase.rs`

## テスト結果

- `cargo fmt --check`: 成功
- `cargo clippy --all-targets --all-features -- -D warnings`: 成功（macOS SDKのclangを明示）
- `cargo test`: 34件成功（macOS SDKのclangを明示）
- 補足: 既定のNix側`cc`では環境依存の`ld: library not found for -liconv`が発生
- GitHub Actions `quality-gate`: 成功

## 制限事項

- VM内READYの通知と停止完了確認は #43 で実装する
- 許可IP管理とIP追加時のパスワード表示は #44 で実装する
- 月次・年次料金表示は #45 で実装する
- 実GCP環境への接続確認は未実施

Closes #38
