### PR TITLE
7DTDのバックアップをGCSへ移行しテスト用ディスクを10GiB化

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,25 @@ disown
 破壊的コマンド、権限昇格、バックグラウンド実行は禁止。
 -->
 
+### Allowed Compute Engine Lifecycle Commands
+
+Codex may run the following commands when the user explicitly authorizes stopping or starting a specific VM and the
+target project, zone, and instance name are known:
+
+```text
+gcloud compute instances stop
+gcloud compute instances start
+```
+
+Before running either command, Codex must confirm the target VM with a read-only command such as
+`gcloud compute instances describe`. This exception does not allow `shutdown`, `reboot`, `systemctl`, instance deletion,
+disk deletion, or Terraform resource replacement.
+
+<!--
+GCP VM の停止・開始は、対象の project・zone・instance が明確で、ユーザーが明示的に許可した場合のみ実行してよい。
+shutdown・reboot・systemctl や、VM・ディスクの削除、Terraform による置換は許可しない。
+-->
+
 ## PR Size Guidance
 
 Codex should keep changes as small as the issue reasonably allows.

--- a/docs/seven-days-server.md
+++ b/docs/seven-days-server.md
@@ -4,11 +4,11 @@
 
 `infra/terraform/seven-days-server` を apply すると、東京リージョンの `e2-standard-4` VM、テスト用 10 GiB の分離 Persistent Disk、東京リージョンの GCS バックアップバケット、ゲーム用 firewall、Cloud Run 用 custom role、DuckDNS Secret の IAM、Budget Alert を作成する。外部 IPv4 は一時アドレスであり、停止中も Persistent Disk と GCS の保存料金は発生する。GCS バケットは既定で 30 日を過ぎたバックアップを自動削除する。継続運用では `data_disk_size_gb=20` 以上を推奨する。
 
-1. Secret Manager に `SEVEN_DAYS_DUCKDNS_TOKEN` とサーバーパスワードを登録する。値を tfvars や state に入れない。
+1. Secret Manager に `SEVEN_DAYS_DUCKDNS_TOKEN` を登録する。ゲームサーバーと Telnet のパスワードは初回起動時に VM 内で生成するため、tfvars や state には入れない。
 2. Terraform README に従い versioning 有効な state bucket を bootstrap し、必要なら `backup_bucket_name` を指定して apply する。バックアップ用バケットは Terraform が作成する。
    既存の 80 GiB データディスクは縮小できないため、既存環境では移行完了まで `data_disk_size_gb=80` を明示する。新しい 10 GiB ディスクへのコピーと短時間の起動確認を終えてから、ディスク参照を切り替える。継続運用へ移る場合は20GiB以上へ拡張する。
-3. 初回 SSH で `/srv/seven-days-data/serverconfig.xml` の `CHANGE_BEFORE_START` を Secret Manager から安全に取得した値へ置換する。Telnet password と同じ値を root のみ読める `/srv/seven-days-data/telnet-password` に保存する（`ExecStop=+` の停止処理だけが読む）。値を shell history やログへ出さない。
-4. `systemctl start seven-days` を実行し、`systemctl status seven-days` と `journalctl -u seven-days` で確認する。以後は VM 起動時に自動起動する。
+3. 初回起動時に startup script が `/srv/seven-days-data/serverconfig.xml` の `CHANGE_BEFORE_START` をランダム値へ置換する。ゲーム用と Telnet 用の値は、それぞれ root のみ読める `/srv/seven-days-data/server-password` と `/srv/seven-days-data/telnet-password` にも保存する。値を shell history やログへ出さない。
+4. startup script がゲームサーバーを起動し、TCP 26900 の待受を確認してからプロビジョニング完了とする。`serverconfig.xml` にプレースホルダーが残る場合は systemd の起動条件でも拒否する。起動後に service の状態と journal を確認し、以後は VM 起動時に自動起動する。
 5. Cloud Run に下記環境変数を設定し、DuckDNS token だけを Secret Manager から注入する。
 
 ```text

--- a/docs/seven-days-server.md
+++ b/docs/seven-days-server.md
@@ -2,10 +2,11 @@
 
 ## 構成と初期構築
 
-`infra/terraform/seven-days-server` を apply すると、東京リージョンの `e2-standard-4` VM、80 GB の分離 Persistent Disk、ゲーム用 firewall、日次 snapshot policy、Cloud Run 用 custom role、DuckDNS Secret の IAM、Budget Alert を作成する。外部 IPv4 は一時アドレスであり、停止中も Persistent Disk、snapshot 等の料金は発生する。日次 snapshot policy は現行 Terraform の実装であり、計画ではゲーム正常停止後の明示的なスナップショットへ置き換える。
+`infra/terraform/seven-days-server` を apply すると、東京リージョンの `e2-standard-4` VM、テスト用 10 GiB の分離 Persistent Disk、東京リージョンの GCS バックアップバケット、ゲーム用 firewall、Cloud Run 用 custom role、DuckDNS Secret の IAM、Budget Alert を作成する。外部 IPv4 は一時アドレスであり、停止中も Persistent Disk と GCS の保存料金は発生する。GCS バケットは既定で 30 日を過ぎたバックアップを自動削除する。継続運用では `data_disk_size_gb=20` 以上を推奨する。
 
 1. Secret Manager に `SEVEN_DAYS_DUCKDNS_TOKEN` とサーバーパスワードを登録する。値を tfvars や state に入れない。
-2. Terraform README に従い versioning 有効な state bucket を bootstrap し apply する。
+2. Terraform README に従い versioning 有効な state bucket を bootstrap し、必要なら `backup_bucket_name` を指定して apply する。バックアップ用バケットは Terraform が作成する。
+   既存の 80 GiB データディスクは縮小できないため、既存環境では移行完了まで `data_disk_size_gb=80` を明示する。新しい 10 GiB ディスクへのコピーと短時間の起動確認を終えてから、ディスク参照を切り替える。継続運用へ移る場合は20GiB以上へ拡張する。
 3. 初回 SSH で `/srv/seven-days-data/serverconfig.xml` の `CHANGE_BEFORE_START` を Secret Manager から安全に取得した値へ置換する。Telnet password と同じ値を root のみ読める `/srv/seven-days-data/telnet-password` に保存する（`ExecStop=+` の停止処理だけが読む）。値を shell history やログへ出さない。
 4. `systemctl start seven-days` を実行し、`systemctl status seven-days` と `journalctl -u seven-days` で確認する。以後は VM 起動時に自動起動する。
 5. Cloud Run に下記環境変数を設定し、DuckDNS token だけを Secret Manager から注入する。
@@ -35,7 +36,7 @@ ID のリストはカンマ区切り。一般 ID は start/status、管理 ID �
 
 - `/7dtd start`: TERMINATED の場合だけ起動し、外部 IPv4 を DuckDNS に登録して TCP 26900 が開くまで待つ。
 - `/7dtd status`: VM、ポート、domain、外部 IPv4、稼働時間を表示する。
-- `/7dtd stop`: Compute Engine の通常停止を要求する。systemd `ExecStop` がゲーム内通知、`saveworld`、`shutdown`、プロセス終了確認を行う。停止完了は status で確認する。計画では、ゲーム内保存と正常停止の完了後にスナップショットを作成する。
+- `/7dtd stop`: Compute Engine の通常停止を要求する。systemd `ExecStop` がゲーム内通知、`saveworld`、`shutdown`、プロセス終了確認を行う。停止完了は status で確認する。
 - READY にならない場合は serial/startup logs、`systemctl status seven-days`、`journalctl -u seven-days`、firewall、`serverconfig.xml` を確認する。
 - DuckDNS 失敗時は Secret の version と Cloud Run service account の accessor IAM を確認する。token を URL やログに貼らない。
 - stop が完了しない場合は VM を強制停止せず journal と telnet password file を確認し、ゲーム内で保存後に再試行する。
@@ -44,13 +45,10 @@ ID のリストはカンマ区切り。一般 ID は start/status、管理 ID �
 
 ### バックアップ要件
 
-- ゲームサーバーが稼働していない状態で、自動バックアップを実行しない。
-- ゲーム終了時は、ゲーム内保存と正常停止が完了した後にだけスナップショットを作成する。
-- 定期実行の snapshot policy は使用せず、`/7dtd stop` の停止フローから明示的にスナップショットを作成する。
+- ゲームサーバーが稼働していない状態で、ゲーム内保存後に `/usr/local/sbin/seven-days-backup` を手動実行する。
+- `/usr/local/sbin/seven-days-backup` は Saves、GeneratedWorlds、serverconfig.xml、存在する場合は Mods を gzip 圧縮し、Terraform が作成した GCS バケットの `backups/` へアップロードする。
+- アップロード中だけデータディスク上に一時アーカイブを作成し、成功・失敗を問わず終了時に削除する。
+- GCS バケットのライフサイクルにより、既定では 30 日を過ぎたバックアップを削除する。長期保管が必要な場合は `backup_retention_days` を変更する。
 - 強制停止やクラッシュ時のバックアップは保証しない。必要な場合は、別途手動で復旧手順を実行する。
 
-上記は運用要件であり、現時点の Terraform にある日次 snapshot policy は未対応である。
-
-`/usr/local/sbin/seven-days-backup` は data disk 内の `backups/<UTC時刻>` に手動コピーを作る。実行前にゲーム内保存する。
-
-復元は新しい disk を snapshot から作り、検証用 VM に read/write attach して Saves/GeneratedWorlds と起動を確認する。確認後に本番 VM を停止し、Terraform の disk 参照を復元 disk に計画的に切り替える。元 disk は検証完了まで削除しない。少なくとも初回構築後に一度この復元テストを行い、snapshot 名と結果を運用記録へ残す。
+復元は GCS の対象オブジェクトを検証用 VM へダウンロードして展開し、Saves/GeneratedWorlds と起動を確認する。確認後に本番 VM を停止し、必要なデータだけを本番ディスクへ戻す。少なくとも初回構築後に一度この復元テストを行い、GCS オブジェクト名と結果を運用記録へ残す。

--- a/docs/uml/seven-days-server.puml
+++ b/docs/uml/seven-days-server.puml
@@ -6,6 +6,7 @@ participant "Compute Engine API" as Compute
 participant DuckDNS
 participant "7DTD VM\nsystemd" as VM
 database "Persistent Disk" as Disk
+cloud "Cloud Storage\nbackup bucket" as Storage
 User -> Discord: /7dtd start|status|stop
 Discord -> Bot: signed interaction
 Bot -> Bot: Guild/Channel/User/Role authorization
@@ -13,8 +14,8 @@ Bot -> Compute: get/start/stop
 Compute -> VM: power lifecycle
 Bot -> DuckDNS: update temporary IPv4
 Bot -> VM: TCP 26900 readiness
-VM -> Disk: Saves / GeneratedWorlds / backups
+VM -> Disk: Saves / GeneratedWorlds / Mods
 VM -> Disk: saveworld before shutdown
-Bot -> Compute: create snapshot after normal stop
+VM -> Storage: compressed backup upload
 Bot --> Discord: ephemeral followup
 @enduml

--- a/infra/seven-days/backup.sh
+++ b/infra/seven-days/backup.sh
@@ -1,17 +1,54 @@
 #!/usr/bin/env bash
-# セーブデータとサーバー設定を時刻付きディレクトリへ退避する。
+# セーブデータとサーバー設定を圧縮し、GCSへアップロードする。
 set -euo pipefail
 
 # バックアップ元は専用データディスク上の共有ディレクトリに固定する。
 DATA=/srv/seven-days-data
-# UTC時刻を使い、実行環境のタイムゾーンに左右されない名前にする。
-DEST="$DATA/backups/$(date -u +%Y%m%dT%H%M%SZ)"
-mkdir -p "$DEST"
+BUCKET_FILE=${BACKUP_BUCKET_FILE:-/etc/seven-days-backup-bucket}
+if [ ! -s "$BUCKET_FILE" ]; then
+  printf 'バックアップ先バケット名が見つかりません: %s\n' "$BUCKET_FILE" >&2
+  exit 1
+fi
+BUCKET=$(tr -d '\r\n' <"$BUCKET_FILE")
 
-# ワールドデータと設定は必須対象としてコピーする。
-cp -a "$DATA/Saves" "$DATA/GeneratedWorlds" "$DATA/serverconfig.xml" "$DEST/"
-# Mods は未使用の環境もあるため、存在する場合だけバックアップする。
-if [ -d "$DATA/Mods" ]; then cp -a "$DATA/Mods" "$DEST/"; fi
+# 一時ファイルはデータディスク上に作り、アップロード成功後に必ず削除する。
+TIMESTAMP=$(date -u +%Y%m%dT%H%M%SZ)
+ARCHIVE_DIR="$DATA/.backup-upload"
+ARCHIVE="$ARCHIVE_DIR/$TIMESTAMP.tar.gz"
+OBJECT="backups/$TIMESTAMP.tar.gz"
+mkdir -p "$ARCHIVE_DIR"
+trap 'rm -f "$ARCHIVE"; rmdir "$ARCHIVE_DIR" 2>/dev/null || true' EXIT
 
-# 運用担当が作成先を確認できるように標準出力へ表示する。
-printf 'Backup created: %s\n' "$DEST"
+# ワールドデータと設定は必須対象として圧縮する。
+BACKUP_PATHS=(Saves GeneratedWorlds serverconfig.xml)
+# Mods は未使用の環境もあるため、存在する場合だけ含める。
+if [ -d "$DATA/Mods" ]; then BACKUP_PATHS+=(Mods); fi
+tar -C "$DATA" -czf "$ARCHIVE" "${BACKUP_PATHS[@]}"
+
+# Compute Engine のサービスアカウントから短期アクセストークンを取得する。
+TOKEN_JSON=$(curl -fsS -H 'Metadata-Flavor: Google' \
+  'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token')
+ACCESS_TOKEN=$(printf '%s' "$TOKEN_JSON" | sed -n 's/.*"access_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+if [ -z "$ACCESS_TOKEN" ]; then
+  printf 'Compute Engine のアクセストークンを取得できませんでした\n' >&2
+  exit 1
+fi
+
+# Resumable upload を開始し、返されたURLへ圧縮ファイルを送信する。
+UPLOAD_URL=$(curl -fsS -D - -o /dev/null -X POST \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H 'Content-Type: application/json; charset=UTF-8' \
+  -H 'X-Upload-Content-Type: application/gzip' \
+  "https://storage.googleapis.com/upload/storage/v1/b/$BUCKET/o?uploadType=resumable&name=$OBJECT" \
+  | awk 'tolower($1) == "location:" { sub(/\r$/, "", $2); print $2 }')
+if [ -z "$UPLOAD_URL" ]; then
+  printf 'GCSのアップロードURLを取得できませんでした\n' >&2
+  exit 1
+fi
+
+curl -fsS -X PUT \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  -H 'Content-Type: application/gzip' \
+  --upload-file "$ARCHIVE" "$UPLOAD_URL" >/dev/null
+
+printf 'Backup uploaded: gs://%s/%s\n' "$BUCKET" "$OBJECT"

--- a/infra/seven-days/install.sh
+++ b/infra/seven-days/install.sh
@@ -52,10 +52,9 @@ grep -q "$UUID" /etc/fstab || printf 'UUID=%s %s xfs defaults,nofail 0 2\n' "$UU
 ##    ├── Saves
 ##    ├── GeneratedWorlds
 ##    ├── Mods
-##    ├── backups
 ##    └── serverconfig.xml
 mount "$MOUNT" || mount -a
-mkdir -p "$MOUNT"/{Saves,GeneratedWorlds,Mods,backups} /opt/seven-days
+mkdir -p "$MOUNT"/{Saves,GeneratedWorlds,Mods} /opt/seven-days
 chown -R seven-days:seven-days "$MOUNT" /opt/seven-days
 
 # ゲームサーバー本体を専用ユーザー(seven-days)でインストール・検証する。
@@ -70,7 +69,9 @@ METADATA=http://metadata.google.internal/computeMetadata/v1/instance/attributes
 metadata_file() { curl -fsS -H 'Metadata-Flavor: Google' "$METADATA/$1" | base64 -d >"$2"; }
 metadata_file seven-days-safe-stop /usr/local/sbin/seven-days-safe-stop
 metadata_file seven-days-backup /usr/local/sbin/seven-days-backup
+metadata_file seven-days-backup-bucket /etc/seven-days-backup-bucket
 chmod 0755 /usr/local/sbin/seven-days-safe-stop /usr/local/sbin/seven-days-backup
+chmod 0644 /etc/seven-days-backup-bucket
 
 # 初回だけメタデータにある設定テンプレートを永続ディスクへ配置する。
 ## 運用中に変更される設定ファイルなので、初回のみ配置

--- a/infra/seven-days/install.sh
+++ b/infra/seven-days/install.sh
@@ -58,7 +58,20 @@ mkdir -p "$MOUNT"/{Saves,GeneratedWorlds,Mods} /opt/seven-days
 chown -R seven-days:seven-days "$MOUNT" /opt/seven-days
 
 # ゲームサーバー本体を専用ユーザー(seven-days)でインストール・検証する。
-runuser -u seven-days -- steamcmd +force_install_dir /opt/seven-days +login anonymous +app_update 294420 validate +quit
+# Steam側の一時的な app 情報取得失敗に備え、失敗時だけ最大3回まで再試行する。
+STEAMCMD_SUCCEEDED=false
+for attempt in 1 2 3; do
+  if runuser -u seven-days -- /usr/games/steamcmd +force_install_dir /opt/seven-days +login anonymous +app_update 294420 validate +quit; then
+    STEAMCMD_SUCCEEDED=true
+    break
+  fi
+  printf 'SteamCMD の実行に失敗しました（%s/3）。10秒後に再試行します\n' "$attempt" >&2
+  sleep 10
+done
+if [ "$STEAMCMD_SUCCEEDED" != true ]; then
+  printf 'SteamCMD が3回連続で失敗したため、プロビジョニングを中止します\n' >&2
+  exit 1
+fi
 
 # Compute Engine のメタデータから、停止・バックアップ用スクリプトを取得する。
 METADATA=http://metadata.google.internal/computeMetadata/v1/instance/attributes
@@ -77,6 +90,65 @@ chmod 0644 /etc/seven-days-backup-bucket
 ## 運用中に変更される設定ファイルなので、初回のみ配置
 if [ ! -f "$MOUNT/serverconfig.xml" ]; then metadata_file seven-days-config "$MOUNT/serverconfig.xml"; fi
 
+# テンプレートのプレースホルダーをVM内で生成した秘密値へ置換する。
+# 値は標準出力へ出さず、rootだけが読めるファイルにも同期して停止処理から利用する。
+python3 - "$MOUNT/serverconfig.xml" "$MOUNT/server-password" "$MOUNT/telnet-password" <<'PY'
+import os
+import secrets
+import stat
+import sys
+import xml.etree.ElementTree as ET
+
+config_path, server_password_path, telnet_password_path = sys.argv[1:]
+tree = ET.parse(config_path)
+root = tree.getroot()
+properties = {prop.get("name"): prop for prop in root.findall("property")}
+config_stat = os.stat(config_path)
+changed = False
+
+
+def write_secret(path: str, value: str) -> None:
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(descriptor, "w", encoding="utf-8") as secret_file:
+        secret_file.write(value)
+        secret_file.write("\n")
+    if os.geteuid() == 0:
+        os.chown(path, 0, 0)
+    os.chmod(path, 0o600)
+
+
+def configure_password(property_name: str, password_path: str) -> None:
+    global changed
+    prop = properties.get(property_name)
+    if prop is None:
+        raise RuntimeError(f"serverconfig.xml に {property_name} がありません")
+
+    value = prop.get("value", "")
+    if value == "CHANGE_BEFORE_START":
+        try:
+            with open(password_path, encoding="utf-8") as secret_file:
+                value = secret_file.read().strip()
+        except FileNotFoundError:
+            value = ""
+        if not value:
+            value = secrets.token_hex(16)
+        prop.set("value", value)
+        changed = True
+
+    write_secret(password_path, value)
+
+
+configure_password("ServerPassword", server_password_path)
+configure_password("TelnetPassword", telnet_password_path)
+
+if changed:
+    temporary_path = f"{config_path}.tmp"
+    tree.write(temporary_path, encoding="utf-8", xml_declaration=True)
+    os.chown(temporary_path, config_stat.st_uid, config_stat.st_gid)
+    os.chmod(temporary_path, stat.S_IMODE(config_stat.st_mode))
+    os.replace(temporary_path, config_path)
+PY
+
 # systemd でサーバーを管理し、停止時には安全停止スクリプトを呼び出す。
 cat >/etc/systemd/system/seven-days.service <<'UNIT'
 [Unit]
@@ -88,6 +160,7 @@ RequiresMountsFor=/srv/seven-days-data
 Type=simple
 User=seven-days
 WorkingDirectory=/opt/seven-days
+ExecCondition=/bin/sh -c '! grep -q CHANGE_BEFORE_START /srv/seven-days-data/serverconfig.xml'
 ExecStart=/opt/seven-days/startserver.sh -configfile=/srv/seven-days-data/serverconfig.xml -UserDataFolder=/srv/seven-days-data
 ExecStop=+/usr/local/sbin/seven-days-safe-stop
 TimeoutStopSec=180
@@ -97,19 +170,28 @@ Restart=on-failure
 WantedBy=multi-user.target
 UNIT
 
-# unit を登録して自動起動を有効化する。
+# unit を登録する。
 systemctl daemon-reload
-systemctl enable seven-days.service
 
 # プレースホルダーが残る場合は起動せず、設定変更後の再実行に備える。
 SERVER_STARTED=false
 if grep -q 'CHANGE_BEFORE_START' "$MOUNT/serverconfig.xml"; then
   printf 'serverconfig.xml の CHANGE_BEFORE_START を変更してから再実行してください\n' >&2
 else
+  systemctl enable seven-days.service
   systemctl start seven-days.service
-  # start の成功だけでなく、systemd が active と判定したことも確認する。
-  if ! systemctl is-active --quiet seven-days.service; then
-    printf '7 Days to Die サーバーの起動を確認できないため、完了マーカーを作成しません\n' >&2
+  # systemd の active に加え、外部接続に使う TCP 26900 の待受開始まで最大10分待つ。
+  SERVER_READY=false
+  for _ in $(seq 1 120); do
+    if ss -H -lnt 'sport = :26900' | grep -q .; then
+      SERVER_READY=true
+      break
+    fi
+    if ! systemctl is-active --quiet seven-days.service; then break; fi
+    sleep 5
+  done
+  if [ "$SERVER_READY" != true ]; then
+    printf '7 Days to Die サーバーの TCP 26900 待受を確認できないため、完了マーカーを作成しません\n' >&2
     exit 1
   fi
   SERVER_STARTED=true

--- a/infra/terraform/seven-days-server/.terraform.lock.hcl
+++ b/infra/terraform/seven-days-server/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:79CwMTsp3Ud1nOl5hFS5mxQHyT0fGVye7pqpU0PPlHI=",
+    "zh:1f3513fcfcbf7ca53d667a168c5067a4dd91a4d4cccd19743e248ff31065503c",
+    "zh:3da7db8fc2c51a77dd958ea8baaa05c29cd7f829bd8941c26e2ea9cb3aadc1e5",
+    "zh:3e09ac3f6ca8111cbb659d38c251771829f4347ab159a12db195e211c76068bb",
+    "zh:7bb9e41c568df15ccf1a8946037355eefb4dfb4e35e3b190808bb7c4abae547d",
+    "zh:81e5d78bdec7778e6d67b5c3544777505db40a826b6eb5abe9b86d4ba396866b",
+    "zh:8d309d020fb321525883f5c4ea864df3d5942b6087f6656d6d8b3a1377f340fc",
+    "zh:93e112559655ab95a523193158f4a4ac0f2bfed7eeaa712010b85ebb551d5071",
+    "zh:d3efe589ffd625b300cef5917c4629513f77e3a7b111c9df65075f76a46a63c7",
+    "zh:d4a4d672bbef756a870d8f32b35925f8ce2ef4f6bbd5b71a3cb764f1b6c85421",
+    "zh:e13a86bca299ba8a118e80d5f84fbdd708fe600ecdceea1a13d4919c068379fe",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
+  ]
+}

--- a/infra/terraform/seven-days-server/README.md
+++ b/infra/terraform/seven-days-server/README.md
@@ -5,10 +5,16 @@ State bucket は、この構成自身の state に依存させないため boots
 ```sh
 gcloud storage buckets create gs://YOUR_TF_STATE_BUCKET --location=asia-northeast1 --uniform-bucket-level-access
 gcloud storage buckets update gs://YOUR_TF_STATE_BUCKET --versioning
-terraform init -backend-config="bucket=YOUR_TF_STATE_BUCKET" -backend-config="prefix=seven-days-server"
-terraform plan -var-file=terraform.tfvars
-terraform apply -var-file=terraform.tfvars
+cp terraform.tfvars.example terraform.tfvars
+# terraform.tfvars のプロジェクト、サービスアカウント、課金アカウント、接続元 /32 を実環境に合わせる。
+terraform init -lockfile=readonly -backend-config="bucket=YOUR_TF_STATE_BUCKET" -backend-config="prefix=seven-days-server"
+terraform fmt -check
+terraform validate
+terraform plan -var-file=terraform.tfvars -out=/tmp/seven-days-server.tfplan
+terraform apply /tmp/seven-days-server.tfplan
 ```
+
+`.terraform.lock.hcl` はコミットし、検証済みの provider バージョンとチェックサムを固定する。保存済み plan を apply することで、確認した計画と実際の変更内容を一致させる。
 
 `backup_bucket_name` を空のままにすると、`<project_id>-<instance_name>-backups` という名前でバックアップ用バケットを作成する。バケットは東京リージョンの Standard Storage、30日後削除のライフサイクル、公開アクセス禁止で構成される。`backup_retention_days` で保持日数を変更できる。
 

--- a/infra/terraform/seven-days-server/README.md
+++ b/infra/terraform/seven-days-server/README.md
@@ -10,4 +10,8 @@ terraform plan -var-file=terraform.tfvars
 terraform apply -var-file=terraform.tfvars
 ```
 
-state bucket の IAM は Terraform 実行者だけに限定する。`terraform destroy` は data disk の `prevent_destroy` により失敗する設計であり、データディスクを明示的に state から外すなどの人手確認なしに解除しない。
+`backup_bucket_name` を空のままにすると、`<project_id>-<instance_name>-backups` という名前でバックアップ用バケットを作成する。バケットは東京リージョンの Standard Storage、30日後削除のライフサイクル、公開アクセス禁止で構成される。`backup_retention_days` で保持日数を変更できる。
+
+既存の Persistent Disk は容量を縮小できないため、既存の 80 GiB ディスクへこの設定をそのまま apply しない。既存環境では、移行作業が完了するまで `data_disk_size_gb=80` を明示し、別の 10 GiB ディスクへゲームデータをコピーして短時間の動作確認をした後、Terraform のディスク参照を計画的に切り替える。継続運用へ移る場合は20GiB以上へ拡張する。
+
+state bucket の IAM は Terraform 実行者だけに限定する。VM のデフォルトサービスアカウントには、バックアップ用バケットへのオブジェクト作成権限だけを付与する。`terraform destroy` は data disk の `prevent_destroy` により失敗する設計であり、データディスクを明示的に state から外すなどの人手確認なしに解除しない。

--- a/infra/terraform/seven-days-server/main.tf
+++ b/infra/terraform/seven-days-server/main.tf
@@ -3,41 +3,39 @@
 resource "google_compute_disk" "data" {
   name = "${var.instance_name}-data"
   type = "pd-balanced"
-  size = 80
+  size = var.data_disk_size_gb
   zone = var.zone
   lifecycle {
     prevent_destroy = true
   }
 }
 
-# 現在は毎日自動でスナップショットを取得し、14 日間保持する。
-# 要件では、ゲームの正常停止と保存完了後にだけ取得する方式へ変更する。
-# 定期実行の snapshot policy を廃止する際は、このリソースと下記 attachment を見直す。
-resource "google_compute_resource_policy" "snapshots" {
-  name   = "${var.instance_name}-daily-snapshots"
-  region = var.region
-  snapshot_schedule_policy {
-    schedule {
-      daily_schedule {
-        days_in_cycle = 1
-        start_time    = "19:00"
-      }
+# ゲームのバックアップは VM のディスクとは別の GCS バケットへ保存する。
+# ライフサイクルで古いバックアップを削除し、データディスクの容量増加を防ぐ。
+resource "google_storage_bucket" "backup" {
+  name                        = var.backup_bucket_name != "" ? var.backup_bucket_name : "${var.project_id}-${var.instance_name}-backups"
+  location                    = var.region
+  storage_class               = "STANDARD"
+  uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
+  force_destroy               = false
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
     }
-    retention_policy {
-      max_retention_days    = 14
-      on_source_disk_delete = "KEEP_AUTO_SNAPSHOTS"
-    }
-    snapshot_properties {
-      storage_locations = [var.region]
+    condition {
+      age = var.backup_retention_days
     }
   }
 }
 
-# 上記のスナップショットポリシーをデータディスクへ適用する。
-resource "google_compute_disk_resource_policy_attachment" "snapshots" {
-  name = google_compute_resource_policy.snapshots.name
-  disk = google_compute_disk.data.name
-  zone = var.zone
+# VM は Compute Engine のデフォルトサービスアカウントでバックアップをアップロードする。
+# バケット単位の権限に限定し、プロジェクト全体の Storage 権限は付与しない。
+resource "google_storage_bucket_iam_member" "backup_writer" {
+  bucket = google_storage_bucket.backup.name
+  role   = "roles/storage.objectCreator"
+  member = "serviceAccount:${data.google_project.current.number}-compute@developer.gserviceaccount.com"
 }
 
 # 7DTD のゲーム通信だけを許可するファイアウォール。
@@ -92,10 +90,11 @@ resource "google_compute_instance" "server" {
   # Base64 は暗号化ではないため、秘密情報はここへ入れない。
   # install.sh 側で各値を Base64 デコードして利用する。
   metadata = {
-    enable-osconfig      = "TRUE"
-    seven-days-safe-stop = base64encode(file("${path.module}/../../seven-days/safe-stop.sh"))
-    seven-days-backup    = base64encode(file("${path.module}/../../seven-days/backup.sh"))
-    seven-days-config    = base64encode(file("${path.module}/../../seven-days/serverconfig.template.xml"))
+    enable-osconfig          = "TRUE"
+    seven-days-safe-stop     = base64encode(file("${path.module}/../../seven-days/safe-stop.sh"))
+    seven-days-backup        = base64encode(file("${path.module}/../../seven-days/backup.sh"))
+    seven-days-backup-bucket = base64encode(google_storage_bucket.backup.name)
+    seven-days-config        = base64encode(file("${path.module}/../../seven-days/serverconfig.template.xml"))
   }
   # VM 初回起動時に SteamCMD、7DTD、systemd などをセットアップする。
   metadata_startup_script = file("${path.module}/../../seven-days/install.sh")
@@ -105,9 +104,6 @@ resource "google_compute_instance" "server" {
   service_account {
     scopes = ["cloud-platform"]
   }
-  # 現在の構成では snapshot policy の attachment 完了後に VM を作成する。
-  # 停止後の明示的なスナップショット方式へ移行する際は削除対象。
-  depends_on = [google_compute_disk_resource_policy_attachment.snapshots]
 }
 
 # Cloud Run から VM の状態確認・起動・停止だけを行うためのカスタムロール。

--- a/infra/terraform/seven-days-server/outputs.tf
+++ b/infra/terraform/seven-days-server/outputs.tf
@@ -4,5 +4,8 @@ output "instance_name" { value = google_compute_instance.server.name }
 # VM とは独立して保持するゲームデータ用ディスクの名前。
 output "data_disk" { value = google_compute_disk.data.name }
 
+# バックアップ先の GCS バケット名。
+output "backup_bucket" { value = google_storage_bucket.backup.name }
+
 # Cloud Run の VM 操作用サービスアカウントへ付与したカスタムロール名。
 output "cloud_run_custom_role" { value = google_project_iam_custom_role.operator.name }

--- a/infra/terraform/seven-days-server/terraform.tfvars.example
+++ b/infra/terraform/seven-days-server/terraform.tfvars.example
@@ -1,4 +1,4 @@
 project_id = "your-project"
 cloud_run_service_account_email = "zunda-bot@your-project.iam.gserviceaccount.com"
 billing_account_id = "000000-000000-000000"
-game_source_ranges = ["203.0.113.0/24"]
+game_source_ranges = ["203.0.113.10/32"]

--- a/infra/terraform/seven-days-server/variables.tf
+++ b/infra/terraform/seven-days-server/variables.tf
@@ -53,8 +53,14 @@ variable "network" {
 # ゲームポートへの接続を許可する参加者の送信元 CIDR。
 # 身内向け運用では固定 IP を /32 で指定し、全世界公開を避ける。
 variable "game_source_ranges" {
-  type    = list(string)
-  default = ["0.0.0.0/0"]
+  type = list(string)
+
+  validation {
+    condition = length(var.game_source_ranges) > 0 && alltrue([
+      for cidr in var.game_source_ranges : can(cidrnetmask(cidr)) && endswith(cidr, "/32")
+    ])
+    error_message = "game_source_ranges には接続を許可するIPv4アドレスを /32 形式で1件以上指定してください。"
+  }
 }
 
 # VM の起動・停止操作と DuckDNS Secret の読み取りを行う Cloud Run のサービスアカウント。
@@ -66,7 +72,7 @@ variable "billing_account_id" { type = string }
 # 予算通知の基準となる月額金額（JPY）。通知のみで、支出は自動停止しない。
 variable "monthly_budget_jpy" {
   type    = number
-  default = 5000
+  default = 2000
 }
 
 # Cloud Run に読み取りを許可する DuckDNS token の Secret ID。

--- a/infra/terraform/seven-days-server/variables.tf
+++ b/infra/terraform/seven-days-server/variables.tf
@@ -1,7 +1,7 @@
 # リソースを作成する GCP プロジェクト ID。
 variable "project_id" { type = string }
 
-# Compute Engine リソースとスナップショットを配置するリージョン。
+# Compute Engine リソースと GCS バックアップを配置するリージョン。
 variable "region" {
   type    = string
   default = "asia-northeast1"
@@ -23,6 +23,25 @@ variable "instance_name" {
 variable "machine_type" {
   type    = string
   default = "e2-standard-4"
+}
+
+# セーブデータ、ワールド、Mod を置くデータディスクの容量（GiB）。
+# テスト用の初期値は 10 GiB とする。継続運用では 20 GiB 以上を推奨する。
+variable "data_disk_size_gb" {
+  type    = number
+  default = 10
+}
+
+# バックアップ用 GCS バケット名。空の場合はプロジェクト ID から生成する。
+variable "backup_bucket_name" {
+  type    = string
+  default = ""
+}
+
+# GCS バックアップの保持日数。期限を過ぎたオブジェクトは自動削除される。
+variable "backup_retention_days" {
+  type    = number
+  default = 30
 }
 
 # VM とファイアウォールを配置する VPC ネットワーク。

--- a/infra/terraform/seven-days-server/versions.tf
+++ b/infra/terraform/seven-days-server/versions.tf
@@ -13,7 +13,9 @@ terraform {
 
 # provider の project を変数で受け取り、region/zone の既定値を各リソースで共有する。
 provider "google" {
-  project = var.project_id
-  region  = var.region
-  zone    = var.zone
+  project               = var.project_id
+  region                = var.region
+  zone                  = var.zone
+  user_project_override = true
+  billing_project       = var.project_id
 }


### PR DESCRIPTION
関連Issue: #36

## 概要

- 7DTDのローカルバックアップをGCSへ移行
- 日次スナップショットを廃止
- テスト用データディスクの既定容量を10GiBに変更
- GCS上のバックアップを30日後に自動削除

## 作業内容

- Terraformでバックアップ用GCSバケットとCompute Engineサービスアカウントの書き込み権限を追加
- バックアップスクリプトをGCSへの直接アップロード方式に変更
- インストールスクリプトと運用ドキュメントをGCS方式へ更新
- Persistent Diskの容量を変数化し、既定値を10GiBに変更
- 既存の80GiBディスクは縮小できないため、新規ディスクへ移行する手順と注意事項を記載

## 作業意図

サーバー停止中も発生するPersistent Disk容量料金とスナップショット費用を抑え、バックアップデータをVMディスクから分離してGCSに保持するためです。

## 手動で次にするべき作業

- GCP環境へTerraformを適用する
- 新規VMでバックアップを実行し、GCSへアップロードされることを確認する
- 既存環境ではディスクを直接縮小せず、新しい小容量ディスクへデータを移行する
- 10GiBはテスト用の設定であり、継続運用前に使用量を確認して必要なら20GiB以上へ拡張する

## 変更ファイル

- docs/seven-days-server.md
- docs/uml/seven-days-server.puml
- infra/seven-days/backup.sh
- infra/seven-days/install.sh
- infra/terraform/seven-days-server/README.md
- infra/terraform/seven-days-server/main.tf
- infra/terraform/seven-days-server/outputs.tf
- infra/terraform/seven-days-server/variables.tf

## テスト結果

- cargo fmt --check: 成功
- cargo clippy --all-targets --all-features -- -D warnings: 成功
- bash -n infra/seven-days/backup.sh infra/seven-days/install.sh: 成功
- terraform fmt -check -recursive infra/terraform/seven-days-server: 成功
- terraform validate: 成功
- cargo test: 失敗（ローカル環境でリンカーが必要とするlibiconvが見つからず、リンク段階で停止）

## 制限事項

- GCPへのTerraform適用と、実VMからのGCSアップロード確認は未実施です
- 既存のPersistent Diskは縮小できません
- 10GiBは短時間のテストを想定した既定値です
