### PR TITLE
7DTDのREADY判定と安全停止を実環境仕様へ同期する

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ gcloud run services describe zunda-bot-rs \
 
 ## 7 Days to Die サーバー
 
-許可された Discord Guild／Channel／User・Role から `/7dtd start`、`/7dtd status`、管理者の `/7dtd stop` を実行できる。GCP 構築、Cloud Run 環境変数、セーブ移行、安全停止、backup／復元は Runbook を参照する。
+許可された Discord Guild／Channel／User・Role から `/7dtd start`、`/7dtd status`、管理者の `/7dtd stop` を実行できる。VM内で確認したゲームポートのREADY状態はGuest Attributes経由でBotへ通知する。GCP 構築、Cloud Run 環境変数、セーブ移行、安全停止、backup／復元は Runbook を参照する。
 READY までの非同期処理を確実に完了させるため、初期構成では Runbook 記載の Cloud Run CPU 設定が必要になる。
 
 ## デバッグ

--- a/docs/seven-days-server.md
+++ b/docs/seven-days-server.md
@@ -8,7 +8,7 @@
 2. Terraform README に従い versioning 有効な state bucket を bootstrap し、必要なら `backup_bucket_name` を指定して apply する。バックアップ用バケットは Terraform が作成する。
    既存の 80 GiB データディスクは縮小できないため、既存環境では移行完了まで `data_disk_size_gb=80` を明示する。新しい 10 GiB ディスクへのコピーと短時間の起動確認を終えてから、ディスク参照を切り替える。継続運用へ移る場合は20GiB以上へ拡張する。
 3. 初回起動時に startup script が `/srv/seven-days-data/serverconfig.xml` の `CHANGE_BEFORE_START` をランダム値へ置換する。ゲーム用と Telnet 用の値は、それぞれ root のみ読める `/srv/seven-days-data/server-password` と `/srv/seven-days-data/telnet-password` にも保存する。値を shell history やログへ出さない。
-4. startup script がゲームサーバーを起動し、TCP 26900 の待受を確認してからプロビジョニング完了とする。`serverconfig.xml` にプレースホルダーが残る場合は systemd の起動条件でも拒否する。起動後に service の状態と journal を確認し、以後は VM 起動時に自動起動する。
+4. startup script がゲームサーバーを起動し、TCP 26900 の待受を確認してから Guest Attributes に起動時刻付きの READY を通知し、プロビジョニング完了とする。`serverconfig.xml` にプレースホルダーが残る場合は systemd の起動条件でも拒否する。起動後に service の状態と journal を確認し、以後は VM 起動時に自動起動する。
 5. Cloud Run に下記環境変数を設定し、DuckDNS token だけを Secret Manager から注入する。
 
 ```text
@@ -34,9 +34,9 @@ ID のリストはカンマ区切り。一般 ID は start/status、管理 ID �
 
 ## 通常運用と障害対応
 
-- `/7dtd start`: TERMINATED の場合だけ起動し、外部 IPv4 を DuckDNS に登録して TCP 26900 が開くまで待つ。
-- `/7dtd status`: VM、ポート、domain、外部 IPv4、稼働時間を表示する。
-- `/7dtd stop`: Compute Engine の通常停止を要求する。systemd `ExecStop` がゲーム内通知、`saveworld`、`shutdown`、プロセス終了確認を行う。停止完了は status で確認する。
+- `/7dtd start`: TERMINATED の場合だけ起動し、外部 IPv4 を DuckDNS に登録して、VM 内で TCP 26900 を確認した現在の起動の READY 通知を待つ。
+- `/7dtd status`: VM、Guest Attributes上のゲーム状態、ポート、domain、外部 IPv4、稼働時間を表示する。
+- `/7dtd stop`: Compute Engine の通常停止を要求する。systemd `ExecStop` がゲーム内通知、`saveworld`、`shutdown`、プロセス終了確認を通常停止猶予内に行い、Botは最大2分停止完了を待つ。
 - READY にならない場合は serial/startup logs、`systemctl status seven-days`、`journalctl -u seven-days`、firewall、`serverconfig.xml` を確認する。
 - DuckDNS 失敗時は Secret の version と Cloud Run service account の accessor IAM を確認する。token を URL やログに貼らない。
 - stop が完了しない場合は VM を強制停止せず journal と telnet password file を確認し、ゲーム内で保存後に再試行する。

--- a/docs/uml/seven-days-server.puml
+++ b/docs/uml/seven-days-server.puml
@@ -7,11 +7,19 @@ participant DuckDNS
 participant "7DTD VM\nsystemd" as VM
 database "Persistent Disk" as Disk
 cloud "Cloud Storage\nbackup bucket" as Storage
+database "PostgreSQL\noperation lock" as OperationLock
 User -> Discord: /7dtd start|status|stop
 Discord -> Bot: signed interaction
 Bot -> Bot: Guild/Channel/User/Role authorization
+Bot -> OperationLock: pg_try_advisory_xact_lock (start/stop)
+alt another start/stop is running
+  OperationLock --> Bot: false
+  Bot --> Discord: 使用中メッセージ（VM APIを呼ばない）
+  break no operation
+else lock acquired
 Bot -> Compute: get/start/stop
 Compute -> VM: power lifecycle
+end
 Bot -> DuckDNS: update temporary IPv4
 VM -> VM: TCP 26900 readiness
 VM -> Compute: Guest Attributes READY

--- a/docs/uml/seven-days-server.puml
+++ b/docs/uml/seven-days-server.puml
@@ -13,7 +13,9 @@ Bot -> Bot: Guild/Channel/User/Role authorization
 Bot -> Compute: get/start/stop
 Compute -> VM: power lifecycle
 Bot -> DuckDNS: update temporary IPv4
-Bot -> VM: TCP 26900 readiness
+VM -> VM: TCP 26900 readiness
+VM -> Compute: Guest Attributes READY
+Bot -> Compute: current boot READY lookup
 VM -> Disk: Saves / GeneratedWorlds / Mods
 VM -> Disk: saveworld before shutdown
 VM -> Storage: compressed backup upload

--- a/infra/seven-days/install.sh
+++ b/infra/seven-days/install.sh
@@ -149,6 +149,39 @@ if changed:
     os.replace(temporary_path, config_path)
 PY
 
+# ゲームサーバーの状態を Compute Engine Guest Attributes へ通知する。
+# 起動時刻を含め、Bot が前回起動時の READY を誤認しないようにする。
+cat >/usr/local/sbin/seven-days-state <<'STATE'
+#!/usr/bin/env bash
+set -euo pipefail
+STATE=${1:?state is required}
+STARTED_AT_FILE=/run/seven-days-started-at
+if [ "$STATE" = STARTING ]; then date -u +%Y-%m-%dT%H:%M:%SZ >"$STARTED_AT_FILE"; fi
+STARTED_AT=$(<"$STARTED_AT_FILE")
+BOOT_ID=$(</proc/sys/kernel/random/boot_id)
+curl -fsS -X PUT \
+  -H 'Metadata-Flavor: Google' \
+  --data "$STATE|$BOOT_ID|$STARTED_AT" \
+  http://metadata.google.internal/computeMetadata/v1/instance/guest-attributes/seven-days/runtime-state \
+  >/dev/null
+STATE
+
+# systemd の ExecStartPost から、TCP 26900 の待受を最大10分確認する。
+cat >/usr/local/sbin/seven-days-ready <<'READY'
+#!/usr/bin/env bash
+set -euo pipefail
+for _ in $(seq 1 120); do
+  if ss -H -lnt 'sport = :26900' | grep -q .; then
+    /usr/local/sbin/seven-days-state READY
+    exit 0
+  fi
+  sleep 5
+done
+/usr/local/sbin/seven-days-state FAILED
+exit 1
+READY
+chmod 0755 /usr/local/sbin/seven-days-state /usr/local/sbin/seven-days-ready
+
 # systemd でサーバーを管理し、停止時には安全停止スクリプトを呼び出す。
 cat >/etc/systemd/system/seven-days.service <<'UNIT'
 [Unit]
@@ -161,9 +194,13 @@ Type=simple
 User=seven-days
 WorkingDirectory=/opt/seven-days
 ExecCondition=/bin/sh -c '! grep -q CHANGE_BEFORE_START /srv/seven-days-data/serverconfig.xml'
+ExecStartPre=+/usr/local/sbin/seven-days-state STARTING
 ExecStart=/opt/seven-days/startserver.sh -configfile=/srv/seven-days-data/serverconfig.xml -UserDataFolder=/srv/seven-days-data
+ExecStartPost=+/usr/local/sbin/seven-days-ready
 ExecStop=+/usr/local/sbin/seven-days-safe-stop
-TimeoutStopSec=180
+ExecStopPost=+/usr/local/sbin/seven-days-state STOPPED
+TimeoutStartSec=620
+TimeoutStopSec=110
 Restart=on-failure
 
 [Install]
@@ -180,17 +217,8 @@ if grep -q 'CHANGE_BEFORE_START' "$MOUNT/serverconfig.xml"; then
 else
   systemctl enable seven-days.service
   systemctl start seven-days.service
-  # systemd の active に加え、外部接続に使う TCP 26900 の待受開始まで最大10分待つ。
-  SERVER_READY=false
-  for _ in $(seq 1 120); do
-    if ss -H -lnt 'sport = :26900' | grep -q .; then
-      SERVER_READY=true
-      break
-    fi
-    if ! systemctl is-active --quiet seven-days.service; then break; fi
-    sleep 5
-  done
-  if [ "$SERVER_READY" != true ]; then
+  # ExecStartPost が TCP 26900 の待受と READY 通知を完了したことを確認する。
+  if ! systemctl is-active --quiet seven-days.service; then
     printf '7 Days to Die サーバーの TCP 26900 待受を確認できないため、完了マーカーを作成しません\n' >&2
     exit 1
   fi

--- a/infra/seven-days/safe-stop.sh
+++ b/infra/seven-days/safe-stop.sh
@@ -16,17 +16,20 @@ if [ -r "$TELNET_PASSWORD_FILE" ]; then
   PASSWORD=$(<"$TELNET_PASSWORD_FILE")
 
   # パスワード入力後に保存を実行し、30秒の告知時間を置いてからサーバーを停止する。
-  {
+  if ! {
     printf '%s\n' "$PASSWORD"
     sleep 1
     printf 'say Server shutting down in 30 seconds\nsaveworld\n'
     sleep 30
     printf 'shutdown\n'
-  } | telnet "$TELNET_HOST" "$TELNET_PORT" >/dev/null
+  } | timeout 40 telnet "$TELNET_HOST" "$TELNET_PORT" >/dev/null; then
+    printf 'Telnet による安全停止要求が完了しませんでした\n' >&2
+  fi
 fi
 
-# 停止要求後、最大120秒間プロセスが終了するのを待つ。
-for _ in $(seq 1 60); do
+# 通知時間を含めて Compute Engine の通常停止猶予120秒以内へ収めるため、
+# 停止要求後のプロセス終了待ちは最大64秒とする。
+for _ in $(seq 1 32); do
   pgrep -f '7DaysToDieServer' >/dev/null || exit 0
   sleep 2
 done

--- a/infra/terraform/seven-days-server/main.tf
+++ b/infra/terraform/seven-days-server/main.tf
@@ -91,6 +91,7 @@ resource "google_compute_instance" "server" {
   # install.sh 側で各値を Base64 デコードして利用する。
   metadata = {
     enable-osconfig          = "TRUE"
+    enable-guest-attributes  = "TRUE"
     seven-days-safe-stop     = base64encode(file("${path.module}/../../seven-days/safe-stop.sh"))
     seven-days-backup        = base64encode(file("${path.module}/../../seven-days/backup.sh"))
     seven-days-backup-bucket = base64encode(google_storage_bucket.backup.name)
@@ -112,7 +113,7 @@ resource "google_compute_instance" "server" {
 resource "google_project_iam_custom_role" "operator" {
   role_id     = "sevenDaysInstanceOperator"
   title       = "7DTD instance operator"
-  permissions = ["compute.instances.get", "compute.instances.start", "compute.instances.stop", "compute.zoneOperations.get"]
+  permissions = ["compute.instances.get", "compute.instances.getGuestAttributes", "compute.instances.start", "compute.instances.stop", "compute.zoneOperations.get"]
 }
 
 # Cloud Run のサービスアカウントへ上記ロールを付与する。

--- a/src/services/seven_days_gcp.rs
+++ b/src/services/seven_days_gcp.rs
@@ -21,6 +21,13 @@ pub struct InstanceStatus {
     pub last_start: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GuestRuntimeState {
+    pub state: String,
+    pub boot_id: String,
+    pub started_at: String,
+}
+
 #[derive(Deserialize)]
 struct AccessToken {
     access_token: String,
@@ -45,6 +52,12 @@ struct NetworkInterface {
 struct AccessConfig {
     #[serde(rename = "natIP")]
     nat_i_p: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct GuestAttributeResponse {
+    #[serde(rename = "variableValue")]
+    variable_value: Option<String>,
 }
 
 impl ComputeClient {
@@ -99,6 +112,26 @@ impl ComputeClient {
             external_ip,
             last_start: response.last_start_timestamp,
         })
+    }
+
+    pub async fn guest_runtime_state(&self) -> Result<Option<GuestRuntimeState>> {
+        let response = self
+            .http
+            .get(format!("{}/getGuestAttributes", self.instance_url()))
+            .query(&[("queryPath", "seven-days/runtime-state")])
+            .bearer_auth(self.token().await?)
+            .send()
+            .await?;
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        let value = response
+            .error_for_status()
+            .context("Compute Engine guest attribute lookup failed")?
+            .json::<GuestAttributeResponse>()
+            .await?
+            .variable_value;
+        value.as_deref().map(parse_guest_runtime_state).transpose()
     }
 
     pub async fn start(&self) -> Result<()> {
@@ -163,6 +196,25 @@ fn redact_request_url(error: reqwest::Error) -> anyhow::Error {
     anyhow::Error::new(error.without_url())
 }
 
+fn parse_guest_runtime_state(value: &str) -> Result<GuestRuntimeState> {
+    let mut fields = value.split('|');
+    let state = fields.next().unwrap_or_default();
+    let boot_id = fields.next().unwrap_or_default();
+    let started_at = fields.next().unwrap_or_default();
+    anyhow::ensure!(
+        !state.is_empty()
+            && !boot_id.is_empty()
+            && !started_at.is_empty()
+            && fields.next().is_none(),
+        "invalid 7DTD guest runtime state"
+    );
+    Ok(GuestRuntimeState {
+        state: state.into(),
+        boot_id: boot_id.into(),
+        started_at: started_at.into(),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -181,5 +233,19 @@ mod tests {
                 .as_deref(),
             Some("203.0.113.10")
         );
+    }
+
+    #[test]
+    fn parses_guest_runtime_state() {
+        assert_eq!(
+            parse_guest_runtime_state("READY|boot-id|2026-08-12T03:00:00Z")
+                .expect("guest state should parse"),
+            GuestRuntimeState {
+                state: "READY".into(),
+                boot_id: "boot-id".into(),
+                started_at: "2026-08-12T03:00:00Z".into(),
+            }
+        );
+        assert!(parse_guest_runtime_state("READY|boot-id").is_err());
     }
 }

--- a/src/usecase/seven_days_usecase.rs
+++ b/src/usecase/seven_days_usecase.rs
@@ -1,12 +1,14 @@
-use crate::services::seven_days_gcp::{ComputeClient, DuckDnsClient, InstanceStatus};
+use crate::services::seven_days_gcp::{
+    ComputeClient, DuckDnsClient, GuestRuntimeState, InstanceStatus,
+};
 use anyhow::{Context as _, Result};
 use chrono::{DateTime, Utc};
 use std::{collections::HashSet, env, time::Duration};
-use tokio::net::TcpStream;
 use tokio::time::Instant;
 
 const START_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 const POLL_INTERVAL: Duration = Duration::from_secs(5);
+const STOP_TIMEOUT: Duration = Duration::from_secs(2 * 60);
 
 #[derive(Clone)]
 pub struct SevenDaysUsecase {
@@ -109,10 +111,11 @@ impl SevenDaysUsecase {
         }
         let ip = status
             .external_ip
+            .clone()
             .context("VM started but external IPv4 was unavailable")?;
         self.duckdns.update(&ip).await?;
         while Instant::now() < deadline {
-            if tcp_ready(&ip, self.port).await {
+            if self.runtime_ready(&status).await? {
                 return Ok(format!(
                     "READY なのだ！ `{}` / `{}:{}`",
                     self.domain, ip, self.port
@@ -128,8 +131,8 @@ impl SevenDaysUsecase {
         let uptime = uptime_minutes(&status, Utc::now())
             .map(|minutes| format!("{minutes}分"))
             .unwrap_or_else(|| "なし".into());
+        let ready = status.state == "RUNNING" && self.runtime_ready(&status).await?;
         let ip = status.external_ip.unwrap_or_else(|| "なし".into());
-        let ready = status.state == "RUNNING" && tcp_ready(&ip, self.port).await;
         Ok(format!(
             "VM: {}\nゲーム: {}\n接続先: `{}:{}`\n外部 IPv4: `{}`\n稼働時間: {}",
             status.state,
@@ -151,16 +154,24 @@ impl SevenDaysUsecase {
             "VM is {state}; refusing a duplicate stop request"
         );
         self.compute.stop().await?;
-        Ok("安全停止を要求したのだ。systemd がワールド保存と正常終了を行ってから VM を停止するのだ。".into())
+        let deadline = Instant::now() + STOP_TIMEOUT;
+        while Instant::now() < deadline {
+            if self.compute.status().await?.state == "TERMINATED" {
+                return Ok("ワールドを保存して VM を安全に停止したのだ。".into());
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+        Ok("安全停止はまだ処理中なのだ。`/7dtd status` で停止完了を確認してほしいのだ。".into())
+    }
+
+    async fn runtime_ready(&self, status: &InstanceStatus) -> Result<bool> {
+        let Some(runtime) = self.compute.guest_runtime_state().await? else {
+            return Ok(false);
+        };
+        Ok(guest_runtime_is_current_and_ready(status, &runtime))
     }
 }
 
-async fn tcp_ready(ip: &str, port: u16) -> bool {
-    tokio::time::timeout(Duration::from_secs(2), TcpStream::connect((ip, port)))
-        .await
-        .map(|r| r.is_ok())
-        .unwrap_or(false)
-}
 fn optional_env(name: &str) -> Option<String> {
     env::var(name).ok().filter(|v| !v.trim().is_empty())
 }
@@ -200,6 +211,26 @@ fn uptime_minutes(status: &InstanceStatus, now: DateTime<Utc>) -> Option<i64> {
         .as_deref()
         .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
         .map(|started| (now - started.with_timezone(&Utc)).num_minutes().max(0))
+}
+
+fn guest_runtime_is_current_and_ready(
+    status: &InstanceStatus,
+    runtime: &GuestRuntimeState,
+) -> bool {
+    if status.state != "RUNNING" || runtime.state != "READY" {
+        return false;
+    }
+    let Some(instance_started) = status
+        .last_start
+        .as_deref()
+        .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+    else {
+        return false;
+    };
+    let Some(runtime_started) = DateTime::parse_from_rfc3339(&runtime.started_at).ok() else {
+        return false;
+    };
+    runtime_started >= instance_started
 }
 
 #[cfg(test)]
@@ -270,5 +301,26 @@ mod tests {
             ..running
         };
         assert_eq!(uptime_minutes(&stopped, now), None);
+    }
+
+    #[test]
+    fn ready_state_must_belong_to_current_start() {
+        let status = InstanceStatus {
+            state: "RUNNING".into(),
+            external_ip: None,
+            last_start: Some("2026-08-12T03:00:00Z".into()),
+        };
+        let current = GuestRuntimeState {
+            state: "READY".into(),
+            boot_id: "new-boot".into(),
+            started_at: "2026-08-12T03:00:01Z".into(),
+        };
+        assert!(guest_runtime_is_current_and_ready(&status, &current));
+
+        let stale = GuestRuntimeState {
+            started_at: "2026-08-11T03:00:00Z".into(),
+            ..current
+        };
+        assert!(!guest_runtime_is_current_and_ready(&status, &stale));
     }
 }


### PR DESCRIPTION
## 概要

- Issue #43: 7DTDの起動READY判定と安全停止を実環境仕様へ追随
- VM内で確認したREADYをGuest Attributes経由でBotへ通知
- 安全停止をCompute Engineの通常停止猶予内へ収める

## 作業内容

- systemdの起動前・READY・停止後にGuest Attributesへ状態を通知
- 起動時刻とboot IDを状態へ含め、前回起動のREADYを除外
- Botから `compute.instances.getGuestAttributes` を呼び出して状態判定
- `/7dtd stop` 後に最大2分 `TERMINATED` を待機
- Telnet停止とプロセス待機を通常停止猶予内へ制限
- Terraform metadataとCloud Run custom roleへ必要設定を追加
- README、Runbook、UMLを同期

## 作業意図

- 参加者IPだけを許可するFirewallとCloud Runからの外部TCP確認が競合するため、VM内の確認結果を安全に取得する
- VM再起動直後に残っている古いREADYを起動成功と誤認しないようにする
- ワールド保存中にCompute Engineから強制停止されるリスクを下げる

## 手動で次にするべき作業

- Terraform planでGuest Attributes有効化とcustom role権限追加だけが含まれることを確認する
- 実VMでSTARTING→READYのGuest Attributes更新を確認する
- `/7dtd stop` でゲーム内通知、saveworld、shutdown、TERMINATEDを確認する

## 変更ファイル

- `README.md`
- `docs/seven-days-server.md`
- `docs/uml/seven-days-server.puml`
- `infra/seven-days/install.sh`
- `infra/seven-days/safe-stop.sh`
- `infra/terraform/seven-days-server/main.tf`
- `src/services/seven_days_gcp.rs`
- `src/usecase/seven_days_usecase.rs`

## テスト結果

- `cargo fmt --check`: 成功
- `cargo clippy --all-targets --all-features -- -D warnings`: 成功
- `cargo test`: ローカル環境で `ld: library not found for -liconv` のため失敗
- `bash -n infra/seven-days/install.sh infra/seven-days/safe-stop.sh infra/seven-days/backup.sh`: 成功
- `terraform fmt -check infra/terraform/seven-days-server/main.tf`: 成功

## 制限事項

- 実GCP VMでの確認は未実施
- Preview版の長時間graceful shutdownは使用せず、通常停止の120秒上限へ収める
- PR #41 を先にマージするstacked PR

Closes #43
