### PR TITLE
Discordから7DTDの許可IPを管理し接続パスワードを表示する

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 dotenvy = "0.15.7"
 ed25519-dalek = "2.1.1"
 hex = "0.4.3"
+base64 = "0.22.1"
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 reqwest = { version = "0.12.22", default-features = false, features = ["json", "rustls-tls"] }

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ gcloud run services describe zunda-bot-rs \
 
 ## 7 Days to Die サーバー
 
-許可された Discord Guild／Channel／User・Role から `/7dtd start`、`/7dtd status`、管理者の `/7dtd stop` を実行できる。VM内で確認したゲームポートのREADY状態はGuest Attributes経由でBotへ通知する。GCP 構築、Cloud Run 環境変数、セーブ移行、安全停止、backup／復元は Runbook を参照する。
+許可された Discord Guild／Channel／User・Role から `/7dtd start`、`/7dtd status`、管理者の `/7dtd stop` と `/7dtd ip list|add|remove` を実行できる。VM内で確認したゲームポートのREADY状態はGuest Attributes経由でBotへ通知する。GCP 構築、Cloud Run 環境変数、セーブ移行、安全停止、接続許可IP、backup／復元は Runbook を参照する。
 READY までの非同期処理を確実に完了させるため、初期構成では Runbook 記載の Cloud Run CPU 設定が必要になる。
 
 ## デバッグ

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ gcloud run services describe zunda-bot-rs \
 
 ## 7 Days to Die サーバー
 
-許可された Discord Guild／Channel／User・Role から `/7dtd status`、管理者から `/7dtd start`、`/7dtd stop`、`/7dtd ip list|add|remove` を実行できる。VM内で確認したゲームポートのREADY状態はGuest Attributes経由でBotへ通知する。GCP 構築、Cloud Run 環境変数、セーブ移行、安全停止、接続許可IP、backup／復元は Runbook を参照する。
+許可された Discord Guild／Channel／User・Role から `/7dtd status`、管理者から `/7dtd start`、`/7dtd stop`、`/7dtd ip list|add|remove` を実行できる。VM内で確認したゲームポートのREADY状態はGuest Attributes経由でBotへ通知し、IP追加時は管理者向けエフェメラル応答に接続先とゲームサーバーパスワードを表示する。GCP 構築、Cloud Run 環境変数、セーブ移行、安全停止、接続許可IP、backup／復元は Runbook を参照する。
 READY までの非同期処理を確実に完了させるため、初期構成では Runbook 記載の Cloud Run CPU 設定が必要になる。
 
 ## デバッグ

--- a/docs/seven-days-server.md
+++ b/docs/seven-days-server.md
@@ -2,18 +2,19 @@
 
 ## 構成と初期構築
 
-`infra/terraform/seven-days-server` を apply すると、東京リージョンの `e2-standard-4` VM、テスト用 10 GiB の分離 Persistent Disk、東京リージョンの GCS バックアップバケット、ゲーム用 firewall、Cloud Run 用 custom role、DuckDNS Secret の IAM、Budget Alert を作成する。外部 IPv4 は一時アドレスであり、停止中も Persistent Disk と GCS の保存料金は発生する。GCS バケットは既定で 30 日を過ぎたバックアップを自動削除する。継続運用では `data_disk_size_gb=20` 以上を推奨する。
+`infra/terraform/seven-days-server` を apply すると、東京リージョンの `e2-standard-4` VM、テスト用 10 GiB の分離 Persistent Disk、東京リージョンの GCS バックアップバケット、ゲームサーバーパスワード用Secret、ゲーム用 firewall、Cloud Run 用 custom role、DuckDNS Secret の IAM、Budget Alert を作成する。外部 IPv4 は一時アドレスであり、停止中も Persistent Disk、GCS、Secret Managerの保存料金は発生する。GCS バケットは既定で 30 日を過ぎたバックアップを自動削除する。継続運用では `data_disk_size_gb=20` 以上を推奨する。
 
-1. Secret Manager に `SEVEN_DAYS_DUCKDNS_TOKEN` を登録する。ゲームサーバーと Telnet のパスワードは初回起動時に VM 内で生成するため、tfvars や state には入れない。
+1. Secret Manager に `SEVEN_DAYS_DUCKDNS_TOKEN` を登録する。ゲームサーバーと Telnet のパスワードは初回起動時に VM 内で生成するため、tfvars や state には入れない。Terraformはゲームサーバーパスワード用Secretの容器だけを作成する。
 2. Terraform README に従い versioning 有効な state bucket を bootstrap し、必要なら `backup_bucket_name` を指定して apply する。バックアップ用バケットは Terraform が作成する。
    既存の 80 GiB データディスクは縮小できないため、既存環境では移行完了まで `data_disk_size_gb=80` を明示する。新しい 10 GiB ディスクへのコピーと短時間の起動確認を終えてから、ディスク参照を切り替える。継続運用へ移る場合は20GiB以上へ拡張する。
-3. 初回起動時に startup script が `/srv/seven-days-data/serverconfig.xml` の `CHANGE_BEFORE_START` をランダム値へ置換する。ゲーム用と Telnet 用の値は、それぞれ root のみ読める `/srv/seven-days-data/server-password` と `/srv/seven-days-data/telnet-password` にも保存する。値を shell history やログへ出さない。
+3. 初回起動時に startup script が `/srv/seven-days-data/serverconfig.xml` の `CHANGE_BEFORE_START` をランダム値へ置換する。ゲーム用と Telnet 用の値は、それぞれ root のみ読める `/srv/seven-days-data/server-password` と `/srv/seven-days-data/telnet-password` にも保存する。ゲーム用の値だけを専用Secretへversionとして同期し、値をmetadata、shell history、Terraform state、通常ログへ出さない。既存VMではTerraform apply後の次回起動時に同期する。
 4. startup script がゲームサーバーを起動し、TCP 26900 の待受を確認してから Guest Attributes に起動時刻付きの READY を通知し、プロビジョニング完了とする。`serverconfig.xml` にプレースホルダーが残る場合は systemd の起動条件でも拒否する。起動後に service の状態と journal を確認し、以後は VM 起動時に自動起動する。
 5. Cloud Run に下記環境変数を設定し、DuckDNS token だけを Secret Manager から注入する。
 
 ```text
 SEVEN_DAYS_GCP_PROJECT, SEVEN_DAYS_GCP_ZONE, SEVEN_DAYS_GCP_INSTANCE
 SEVEN_DAYS_GCP_NETWORK, SEVEN_DAYS_MAX_ALLOWED_IPS
+SEVEN_DAYS_SERVER_PASSWORD_SECRET_ID
 SEVEN_DAYS_DUCKDNS_DOMAIN, SEVEN_DAYS_DUCKDNS_TOKEN, SEVEN_DAYS_PORT
 SEVEN_DAYS_DISCORD_GUILD_ID, SEVEN_DAYS_DISCORD_CHANNEL_ID
 SEVEN_DAYS_DISCORD_USER_IDS, SEVEN_DAYS_DISCORD_ROLE_IDS
@@ -21,7 +22,7 @@ SEVEN_DAYS_DISCORD_ADMIN_USER_IDS, SEVEN_DAYS_DISCORD_ADMIN_ROLE_IDS
 ```
 
 ID のリストはカンマ区切り。一般 ID は status、管理 ID は start/status/stop を実行できる。
-`SEVEN_DAYS_GCP_NETWORK` の既定値は `default`、Botが管理する許可IPの上限 `SEVEN_DAYS_MAX_ALLOWED_IPS` の既定値は16件。`/7dtd ip list|add|remove` は管理者だけが実行でき、グローバルIPv4をIPごとのBot管理Firewall ruleとして追加・削除する。Terraform管理の既存game ruleは変更しない。
+`SEVEN_DAYS_GCP_NETWORK` の既定値は `default`、Botが管理する許可IPの上限 `SEVEN_DAYS_MAX_ALLOWED_IPS` の既定値は16件、`SEVEN_DAYS_SERVER_PASSWORD_SECRET_ID` の既定値は `SEVEN_DAYS_SERVER_PASSWORD`。`/7dtd ip list|add|remove` は管理者だけが実行でき、グローバルIPv4をIPごとのBot管理Firewall ruleとして追加・削除する。Terraform管理の既存game ruleは変更しない。
 
 ゲームサーバーは身内の 2〜4 人だけで利用する。`game_source_ranges` には参加者の固定 IPv4 を `/32` で指定し、ゲーム用ポートへの接続元を限定する。VPN は利用しない。自宅回線の IP が変わった場合は、Terraform の値を更新して再 apply する。SSH などの管理用ポートを全世界へ公開しない。
 
@@ -39,9 +40,10 @@ ID のリストはカンマ区切り。一般 ID は status、管理 ID は star
 - `/7dtd start`: 管理者限定。TERMINATED の場合だけ起動し、外部 IPv4 を DuckDNS に登録して、VM 内で TCP 26900 を確認した現在の起動の READY 通知を待つ。
 - `/7dtd status`: VM、Guest Attributes上のゲーム状態、ポート、domain、外部 IPv4、稼働時間を表示する。
 - `/7dtd stop`: 管理者限定。Compute Engine の通常停止を要求する。systemd `ExecStop` がゲーム内通知、`saveworld`、`shutdown`、プロセス終了確認を通常停止猶予内に行い、Botは最大2分停止完了を待つ。
-- `/7dtd ip list|add|remove`: 管理者限定。Bot管理の接続許可IPv4を確認・追加・削除する。private、loopback、link-local、multicastなどの非グローバルIPは拒否する。
+- `/7dtd ip list|add|remove`: 管理者限定。Bot管理の接続許可IPv4を確認・追加・削除する。private、loopback、link-local、multicastなどの非グローバルIPは拒否する。`ip add`はFirewall変更前に専用Secretを取得し、成功時のエフェメラル応答へ接続先とゲームサーバーパスワードを表示する。Secretを取得できない場合はFirewallを追加しない。
 - READY にならない場合は serial/startup logs、`systemctl status seven-days`、`journalctl -u seven-days`、firewall、`serverconfig.xml` を確認する。
 - DuckDNS 失敗時は Secret の version と Cloud Run service account の accessor IAM を確認する。token を URL やログに貼らない。
+- `ip add`でパスワードを取得できない場合は、専用Secretに有効なversionがあること、VMのversion追加IAM、Cloud Runのaccessor IAM、Secret IDを確認する。エフェメラル応答でも管理者がコピー・転送できるため、管理者ID・Roleは必要最小限にする。
 - stop が完了しない場合は VM を強制停止せず journal と telnet password file を確認し、ゲーム内で保存後に再試行する。
 
 ## Backup と復元確認

--- a/docs/seven-days-server.md
+++ b/docs/seven-days-server.md
@@ -13,6 +13,7 @@
 
 ```text
 SEVEN_DAYS_GCP_PROJECT, SEVEN_DAYS_GCP_ZONE, SEVEN_DAYS_GCP_INSTANCE
+SEVEN_DAYS_GCP_NETWORK, SEVEN_DAYS_MAX_ALLOWED_IPS
 SEVEN_DAYS_DUCKDNS_DOMAIN, SEVEN_DAYS_DUCKDNS_TOKEN, SEVEN_DAYS_PORT
 SEVEN_DAYS_DISCORD_GUILD_ID, SEVEN_DAYS_DISCORD_CHANNEL_ID
 SEVEN_DAYS_DISCORD_USER_IDS, SEVEN_DAYS_DISCORD_ROLE_IDS
@@ -20,6 +21,7 @@ SEVEN_DAYS_DISCORD_ADMIN_USER_IDS, SEVEN_DAYS_DISCORD_ADMIN_ROLE_IDS
 ```
 
 ID のリストはカンマ区切り。一般 ID は start/status、管理 ID は start/status/stop を実行できる。
+`SEVEN_DAYS_GCP_NETWORK` の既定値は `default`、Botが管理する許可IPの上限 `SEVEN_DAYS_MAX_ALLOWED_IPS` の既定値は16件。`/7dtd ip list|add|remove` は管理者だけが実行でき、グローバルIPv4をIPごとのBot管理Firewall ruleとして追加・削除する。Terraform管理の既存game ruleは変更しない。
 
 ゲームサーバーは身内の 2〜4 人だけで利用する。`game_source_ranges` には参加者の固定 IPv4 を `/32` で指定し、ゲーム用ポートへの接続元を限定する。VPN は利用しない。自宅回線の IP が変わった場合は、Terraform の値を更新して再 apply する。SSH などの管理用ポートを全世界へ公開しない。
 
@@ -37,6 +39,7 @@ ID のリストはカンマ区切り。一般 ID は start/status、管理 ID �
 - `/7dtd start`: TERMINATED の場合だけ起動し、外部 IPv4 を DuckDNS に登録して、VM 内で TCP 26900 を確認した現在の起動の READY 通知を待つ。
 - `/7dtd status`: VM、Guest Attributes上のゲーム状態、ポート、domain、外部 IPv4、稼働時間を表示する。
 - `/7dtd stop`: Compute Engine の通常停止を要求する。systemd `ExecStop` がゲーム内通知、`saveworld`、`shutdown`、プロセス終了確認を通常停止猶予内に行い、Botは最大2分停止完了を待つ。
+- `/7dtd ip list|add|remove`: 管理者がBot管理の接続許可IPv4を確認・追加・削除する。private、loopback、link-local、multicastなどの非グローバルIPは拒否する。
 - READY にならない場合は serial/startup logs、`systemctl status seven-days`、`journalctl -u seven-days`、firewall、`serverconfig.xml` を確認する。
 - DuckDNS 失敗時は Secret の version と Cloud Run service account の accessor IAM を確認する。token を URL やログに貼らない。
 - stop が完了しない場合は VM を強制停止せず journal と telnet password file を確認し、ゲーム内で保存後に再試行する。

--- a/docs/uml/seven-days-server.puml
+++ b/docs/uml/seven-days-server.puml
@@ -7,6 +7,7 @@ participant DuckDNS
 participant "7DTD VM\nsystemd" as VM
 database "Persistent Disk" as Disk
 cloud "Cloud Storage\nbackup bucket" as Storage
+database "Secret Manager\nserver password" as Secret
 User -> Discord: /7dtd start|status|stop|ip
 Discord -> Bot: signed interaction
 Bot -> Bot: Guild/Channel/User/Role authorization
@@ -17,8 +18,10 @@ VM -> VM: TCP 26900 readiness
 VM -> Compute: Guest Attributes READY
 Bot -> Compute: current boot READY lookup
 Bot -> Compute: managed firewall list/create/delete
+VM -> Secret: add generated password version
+Bot -> Secret: access password after admin IP add
 VM -> Disk: Saves / GeneratedWorlds / Mods
 VM -> Disk: saveworld before shutdown
 VM -> Storage: compressed backup upload
-Bot --> Discord: ephemeral followup
+Bot --> Discord: ephemeral followup / connection password
 @enduml

--- a/docs/uml/seven-days-server.puml
+++ b/docs/uml/seven-days-server.puml
@@ -7,7 +7,7 @@ participant DuckDNS
 participant "7DTD VM\nsystemd" as VM
 database "Persistent Disk" as Disk
 cloud "Cloud Storage\nbackup bucket" as Storage
-User -> Discord: /7dtd start|status|stop
+User -> Discord: /7dtd start|status|stop|ip
 Discord -> Bot: signed interaction
 Bot -> Bot: Guild/Channel/User/Role authorization
 Bot -> Compute: get/start/stop
@@ -16,6 +16,7 @@ Bot -> DuckDNS: update temporary IPv4
 VM -> VM: TCP 26900 readiness
 VM -> Compute: Guest Attributes READY
 Bot -> Compute: current boot READY lookup
+Bot -> Compute: managed firewall list/create/delete
 VM -> Disk: Saves / GeneratedWorlds / Mods
 VM -> Disk: saveworld before shutdown
 VM -> Storage: compressed backup upload

--- a/docs/uml/seven-days-server.puml
+++ b/docs/uml/seven-days-server.puml
@@ -8,11 +8,19 @@ participant "7DTD VM\nsystemd" as VM
 database "Persistent Disk" as Disk
 cloud "Cloud Storage\nbackup bucket" as Storage
 database "Secret Manager\nserver password" as Secret
+database "PostgreSQL\noperation lock" as OperationLock
 User -> Discord: /7dtd start|status|stop|ip
 Discord -> Bot: signed interaction
 Bot -> Bot: Guild/Channel/User/Role authorization
+Bot -> OperationLock: pg_try_advisory_xact_lock (start/stop)
+alt another start/stop is running
+  OperationLock --> Bot: false
+  Bot --> Discord: 使用中メッセージ（VM APIを呼ばない）
+  break no operation
+else lock acquired
 Bot -> Compute: get/start/stop
 Compute -> VM: power lifecycle
+end
 Bot -> DuckDNS: update temporary IPv4
 VM -> VM: TCP 26900 readiness
 VM -> Compute: Guest Attributes READY

--- a/infra/seven-days/install.sh
+++ b/infra/seven-days/install.sh
@@ -4,8 +4,98 @@ set -euo pipefail
 # apt の対話プロンプトを無効化し、起動時に自動実行できるようにする。
 export DEBIAN_FRONTEND=noninteractive
 
+MOUNT=/srv/seven-days-data
+METADATA_ROOT=http://metadata.google.internal/computeMetadata/v1
+
+# ゲームサーバーパスワードを専用Secretへ同期する。値は引数・標準出力・Guest Attributesへ出さない。
+sync_server_password_secret() {
+  local secret_file="$MOUNT/server-password"
+  local hash_file="$MOUNT/server-password-secret.sha256"
+  local secret_id
+  [ -s "$secret_file" ] || return 0
+  if ! secret_id=$(curl -fsS -H 'Metadata-Flavor: Google' \
+    "$METADATA_ROOT/instance/attributes/seven-days-server-password-secret"); then
+    return 1
+  fi
+  [ -n "$secret_id" ] || return 1
+  python3 - "$secret_file" "$hash_file" "$secret_id" <<'PY'
+import base64
+import hashlib
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+
+password_path, hash_path, secret_id = sys.argv[1:]
+with open(password_path, "rb") as password_file:
+    password = password_file.read().strip()
+if not password:
+    raise RuntimeError("ゲームサーバーパスワードが空です")
+
+digest = hashlib.sha256(password).hexdigest()
+try:
+    with open(hash_path, encoding="ascii") as hash_file:
+        if hash_file.read().strip() == digest:
+            raise SystemExit(0)
+except FileNotFoundError:
+    pass
+
+metadata_root = "http://metadata.google.internal/computeMetadata/v1"
+
+
+def metadata(path: str) -> bytes:
+    request = urllib.request.Request(
+        f"{metadata_root}/{path}", headers={"Metadata-Flavor": "Google"}
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        return response.read()
+
+
+project_id = metadata("project/project-id").decode("ascii")
+token = json.loads(metadata("instance/service-accounts/default/token"))["access_token"]
+url = (
+    "https://secretmanager.googleapis.com/v1/projects/"
+    f"{urllib.parse.quote(project_id, safe='')}/secrets/"
+    f"{urllib.parse.quote(secret_id.strip(), safe='')}:addVersion"
+)
+body = json.dumps(
+    {"payload": {"data": base64.b64encode(password).decode("ascii")}}
+).encode("utf-8")
+request = urllib.request.Request(
+    url,
+    data=body,
+    method="POST",
+    headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+)
+for attempt in range(6):
+    try:
+        with urllib.request.urlopen(request, timeout=20):
+            break
+    except urllib.error.HTTPError as error:
+        if error.code not in {403, 429, 500, 502, 503, 504} or attempt == 5:
+            raise
+        time.sleep(5)
+
+temporary_path = f"{hash_path}.tmp"
+descriptor = os.open(temporary_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+with os.fdopen(descriptor, "w", encoding="ascii") as hash_file:
+    hash_file.write(digest)
+    hash_file.write("\n")
+os.chmod(temporary_path, 0o600)
+os.replace(temporary_path, hash_path)
+PY
+}
+
 # 完了マーカーがある場合は再実行せず、既存環境を変更しない。
-if [ -f /var/lib/seven-days-provisioned ]; then exit 0; fi
+if [ -f /var/lib/seven-days-provisioned ]; then
+  if ! sync_server_password_secret; then
+    printf 'ゲームサーバーパスワードのSecret同期に失敗しました。次回起動時に再試行します\n' >&2
+  fi
+  exit 0
+fi
 
 # SteamCMD と、データディスクを扱うためのツールをインストールする。
 apt-get update
@@ -27,7 +117,6 @@ id seven-days >/dev/null 2>&1 || useradd --system --create-home --shell /usr/sbi
 ## デバイス(ディスク操作用 - ゲームデータを書き込むと、XFSの構造を壊したり、データを上書きする危険があるので直接触らない)
 DEVICE=/dev/disk/by-id/google-seven-days-data
 ## マウントポイント(ファイル操作用)
-MOUNT=/srv/seven-days-data
 mkdir -p "$MOUNT"
 ## XFSとしてフォーマットし、ディスク内部にUUIDを保存
 if ! blkid "$DEVICE" >/dev/null 2>&1; then mkfs.xfs "$DEVICE"; fi
@@ -148,6 +237,9 @@ if changed:
     os.chmod(temporary_path, stat.S_IMODE(config_stat.st_mode))
     os.replace(temporary_path, config_path)
 PY
+
+# Secret同期に失敗した場合はFirewall追加前に検知できるよう、初期構築を完了扱いにしない。
+sync_server_password_secret
 
 # ゲームサーバーの状態を Compute Engine Guest Attributes へ通知する。
 # 起動時刻を含め、Bot が前回起動時の READY を誤認しないようにする。

--- a/infra/terraform/seven-days-server/README.md
+++ b/infra/terraform/seven-days-server/README.md
@@ -18,6 +18,8 @@ terraform apply /tmp/seven-days-server.tfplan
 
 `backup_bucket_name` を空のままにすると、`<project_id>-<instance_name>-backups` という名前でバックアップ用バケットを作成する。バケットは東京リージョンの Standard Storage、30日後削除のライフサイクル、公開アクセス禁止で構成される。`backup_retention_days` で保持日数を変更できる。
 
+Terraformは`server_password_secret_id`の専用Secretを作成するが、パスワード値をstateへ保存しない。VMはゲームサーバーパスワード生成後にこのSecretへversionを追加し、Cloud Runは`/7dtd ip add`時に読み取る。既存VMではapply後に一度起動して同期し、output `server_password_secret_id`と有効なversionを確認してからIP追加を試す。Secretには`prevent_destroy`を設定しているため、削除が必要な場合は値の退避と人手確認を先に行う。
+
 既存の Persistent Disk は容量を縮小できないため、既存の 80 GiB ディスクへこの設定をそのまま apply しない。既存環境では、移行作業が完了するまで `data_disk_size_gb=80` を明示し、別の 10 GiB ディスクへゲームデータをコピーして短時間の動作確認をした後、Terraform のディスク参照を計画的に切り替える。継続運用へ移る場合は20GiB以上へ拡張する。
 
 state bucket の IAM は Terraform 実行者だけに限定する。VM のデフォルトサービスアカウントには、バックアップ用バケットへのオブジェクト作成権限だけを付与する。`terraform destroy` は data disk の `prevent_destroy` により失敗する設計であり、データディスクを明示的に state から外すなどの人手確認なしに解除しない。

--- a/infra/terraform/seven-days-server/main.tf
+++ b/infra/terraform/seven-days-server/main.tf
@@ -111,9 +111,19 @@ resource "google_compute_instance" "server" {
 # プロジェクトへ付与するため、同じプロジェクト内の他 VM も対象になり得る。
 # 専用プロジェクトまたは VM 単位の IAM を検討する。
 resource "google_project_iam_custom_role" "operator" {
-  role_id     = "sevenDaysInstanceOperator"
-  title       = "7DTD instance operator"
-  permissions = ["compute.instances.get", "compute.instances.getGuestAttributes", "compute.instances.start", "compute.instances.stop", "compute.zoneOperations.get"]
+  role_id = "sevenDaysInstanceOperator"
+  title   = "7DTD instance operator"
+  permissions = [
+    "compute.firewalls.create",
+    "compute.firewalls.delete",
+    "compute.firewalls.get",
+    "compute.firewalls.list",
+    "compute.instances.get",
+    "compute.instances.getGuestAttributes",
+    "compute.instances.start",
+    "compute.instances.stop",
+    "compute.zoneOperations.get",
+  ]
 }
 
 # Cloud Run のサービスアカウントへ上記ロールを付与する。

--- a/infra/terraform/seven-days-server/main.tf
+++ b/infra/terraform/seven-days-server/main.tf
@@ -38,6 +38,40 @@ resource "google_storage_bucket_iam_member" "backup_writer" {
   member = "serviceAccount:${data.google_project.current.number}-compute@developer.gserviceaccount.com"
 }
 
+# ゲームサーバーパスワードの値はTerraformで扱わず、専用Secretの容器だけを作成する。
+resource "google_project_service" "secretmanager" {
+  project            = var.project_id
+  service            = "secretmanager.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_secret_manager_secret" "server_password" {
+  project   = var.project_id
+  secret_id = var.server_password_secret_id
+  replication {
+    auto {}
+  }
+  lifecycle {
+    prevent_destroy = true
+  }
+  depends_on = [google_project_service.secretmanager]
+}
+
+# VMは生成したパスワードのversion追加だけ、Cloud Runは読み取りだけを許可する。
+resource "google_secret_manager_secret_iam_member" "server_password_writer" {
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.server_password.secret_id
+  role      = "roles/secretmanager.secretVersionAdder"
+  member    = "serviceAccount:${data.google_project.current.number}-compute@developer.gserviceaccount.com"
+}
+
+resource "google_secret_manager_secret_iam_member" "server_password_reader" {
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.server_password.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${var.cloud_run_service_account_email}"
+}
+
 # 7DTD のゲーム通信だけを許可するファイアウォール。
 # source_ranges は参加者の固定 IP (/32) を指定することを想定する。
 # 0.0.0.0/0 を使う場合でも、ここで指定したゲームポート以外は公開しない。
@@ -90,12 +124,13 @@ resource "google_compute_instance" "server" {
   # Base64 は暗号化ではないため、秘密情報はここへ入れない。
   # install.sh 側で各値を Base64 デコードして利用する。
   metadata = {
-    enable-osconfig          = "TRUE"
-    enable-guest-attributes  = "TRUE"
-    seven-days-safe-stop     = base64encode(file("${path.module}/../../seven-days/safe-stop.sh"))
-    seven-days-backup        = base64encode(file("${path.module}/../../seven-days/backup.sh"))
-    seven-days-backup-bucket = base64encode(google_storage_bucket.backup.name)
-    seven-days-config        = base64encode(file("${path.module}/../../seven-days/serverconfig.template.xml"))
+    enable-osconfig                   = "TRUE"
+    enable-guest-attributes           = "TRUE"
+    seven-days-safe-stop              = base64encode(file("${path.module}/../../seven-days/safe-stop.sh"))
+    seven-days-backup                 = base64encode(file("${path.module}/../../seven-days/backup.sh"))
+    seven-days-backup-bucket          = base64encode(google_storage_bucket.backup.name)
+    seven-days-config                 = base64encode(file("${path.module}/../../seven-days/serverconfig.template.xml"))
+    seven-days-server-password-secret = google_secret_manager_secret.server_password.secret_id
   }
   # VM 初回起動時に SteamCMD、7DTD、systemd などをセットアップする。
   metadata_startup_script = file("${path.module}/../../seven-days/install.sh")
@@ -105,6 +140,8 @@ resource "google_compute_instance" "server" {
   service_account {
     scopes = ["cloud-platform"]
   }
+
+  depends_on = [google_secret_manager_secret_iam_member.server_password_writer]
 }
 
 # Cloud Run から VM の状態確認・起動・停止だけを行うためのカスタムロール。

--- a/infra/terraform/seven-days-server/outputs.tf
+++ b/infra/terraform/seven-days-server/outputs.tf
@@ -9,3 +9,6 @@ output "backup_bucket" { value = google_storage_bucket.backup.name }
 
 # Cloud Run の VM 操作用サービスアカウントへ付与したカスタムロール名。
 output "cloud_run_custom_role" { value = google_project_iam_custom_role.operator.name }
+
+# 値は出力せず、Cloud Run設定に使うゲームサーバーパスワードのSecret IDだけを出力する。
+output "server_password_secret_id" { value = google_secret_manager_secret.server_password.secret_id }

--- a/infra/terraform/seven-days-server/terraform.tfvars.example
+++ b/infra/terraform/seven-days-server/terraform.tfvars.example
@@ -2,3 +2,4 @@ project_id = "your-project"
 cloud_run_service_account_email = "zunda-bot@your-project.iam.gserviceaccount.com"
 billing_account_id = "000000-000000-000000"
 game_source_ranges = ["203.0.113.10/32"]
+server_password_secret_id = "SEVEN_DAYS_SERVER_PASSWORD"

--- a/infra/terraform/seven-days-server/variables.tf
+++ b/infra/terraform/seven-days-server/variables.tf
@@ -80,3 +80,9 @@ variable "duckdns_secret_id" {
   type    = string
   default = "SEVEN_DAYS_DUCKDNS_TOKEN"
 }
+
+# VMがゲームサーバーパスワードを同期し、Cloud RunがIP追加時に読む専用Secret ID。
+variable "server_password_secret_id" {
+  type    = string
+  default = "SEVEN_DAYS_SERVER_PASSWORD"
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -159,6 +159,48 @@ fn seven_days_command() -> CreateCommand {
             "stop",
             "サーバーを安全に停止するのだ",
         ))
+        .add_option(
+            CreateCommandOption::new(
+                CommandOptionType::SubCommandGroup,
+                "ip",
+                "ゲームへの接続許可IPを管理するのだ",
+            )
+            .add_sub_option(CreateCommandOption::new(
+                CommandOptionType::SubCommand,
+                "list",
+                "接続許可IPを一覧するのだ",
+            ))
+            .add_sub_option(
+                CreateCommandOption::new(
+                    CommandOptionType::SubCommand,
+                    "add",
+                    "接続許可IPを追加するのだ",
+                )
+                .add_sub_option(
+                    CreateCommandOption::new(
+                        CommandOptionType::String,
+                        "address",
+                        "追加するグローバルIPv4アドレス",
+                    )
+                    .required(true),
+                ),
+            )
+            .add_sub_option(
+                CreateCommandOption::new(
+                    CommandOptionType::SubCommand,
+                    "remove",
+                    "接続許可IPを削除するのだ",
+                )
+                .add_sub_option(
+                    CreateCommandOption::new(
+                        CommandOptionType::String,
+                        "address",
+                        "削除するグローバルIPv4アドレス",
+                    )
+                    .required(true),
+                ),
+            ),
+        )
 }
 
 fn hello_command() -> CreateCommand {

--- a/src/services/interaction_webhook.rs
+++ b/src/services/interaction_webhook.rs
@@ -235,7 +235,10 @@ async fn handle_deferred_application_command(
         }
         ApplicationCommandRoute::SevenDaysStart
         | ApplicationCommandRoute::SevenDaysStatus
-        | ApplicationCommandRoute::SevenDaysStop => {
+        | ApplicationCommandRoute::SevenDaysStop
+        | ApplicationCommandRoute::SevenDaysIpList
+        | ApplicationCommandRoute::SevenDaysIpAdd
+        | ApplicationCommandRoute::SevenDaysIpRemove => {
             let Some(usecase) = &data.seven_days_usecase else {
                 return Ok(discord_response(message(
                     "7DTD サーバーは設定されていないのだ。",
@@ -247,7 +250,13 @@ async fn handle_deferred_application_command(
                 user_id: member_id,
                 role_ids: &role_ids,
             };
-            let admin = route == ApplicationCommandRoute::SevenDaysStop;
+            let admin = matches!(
+                route,
+                ApplicationCommandRoute::SevenDaysStop
+                    | ApplicationCommandRoute::SevenDaysIpList
+                    | ApplicationCommandRoute::SevenDaysIpAdd
+                    | ApplicationCommandRoute::SevenDaysIpRemove
+            );
             if !usecase.authorize(&caller, admin) {
                 tracing::warn!(?guild_id, ?channel_id, user_id = ?member_id, command = ?route, "unauthorized 7DTD command");
                 return Ok(discord_response(message(
@@ -259,6 +268,21 @@ async fn handle_deferred_application_command(
                 ApplicationCommandRoute::SevenDaysStart => usecase.start().await,
                 ApplicationCommandRoute::SevenDaysStatus => usecase.status().await,
                 ApplicationCommandRoute::SevenDaysStop => usecase.stop().await,
+                ApplicationCommandRoute::SevenDaysIpList => usecase.list_allowed_ips().await,
+                ApplicationCommandRoute::SevenDaysIpAdd => {
+                    let address = command_data
+                        .nested_subcommand_option_value("address")
+                        .and_then(Value::as_str)
+                        .context("address option missing")?;
+                    usecase.add_allowed_ip(address).await
+                }
+                ApplicationCommandRoute::SevenDaysIpRemove => {
+                    let address = command_data
+                        .nested_subcommand_option_value("address")
+                        .and_then(Value::as_str)
+                        .context("address option missing")?;
+                    usecase.remove_allowed_ip(address).await
+                }
                 _ => unreachable!(),
             };
             match result {
@@ -538,6 +562,9 @@ pub enum ApplicationCommandRoute {
     SevenDaysStart,
     SevenDaysStatus,
     SevenDaysStop,
+    SevenDaysIpList,
+    SevenDaysIpAdd,
+    SevenDaysIpRemove,
 }
 
 impl ApplicationCommandRoute {
@@ -564,6 +591,12 @@ impl ApplicationCommandRoute {
                 "start" => Some(Self::SevenDaysStart),
                 "status" => Some(Self::SevenDaysStatus),
                 "stop" => Some(Self::SevenDaysStop),
+                "ip" => match data.options.first()?.options.first()?.name.as_str() {
+                    "list" => Some(Self::SevenDaysIpList),
+                    "add" => Some(Self::SevenDaysIpAdd),
+                    "remove" => Some(Self::SevenDaysIpRemove),
+                    _ => None,
+                },
                 _ => None,
             },
             _ => None,
@@ -625,6 +658,18 @@ struct ApplicationCommandData {
 impl ApplicationCommandData {
     fn subcommand_option_value(&self, option_name: &str) -> Option<&Value> {
         self.options
+            .first()?
+            .options
+            .iter()
+            .find(|option| option.name == option_name)?
+            .value
+            .as_ref()
+    }
+
+    fn nested_subcommand_option_value(&self, option_name: &str) -> Option<&Value> {
+        self.options
+            .first()?
+            .options
             .first()?
             .options
             .iter()
@@ -744,6 +789,22 @@ mod tests {
                 Some(expected)
             );
         }
+    }
+
+    #[test]
+    fn routes_seven_days_ip_command_and_reads_address() {
+        let data = command_data(
+            r#"{"type":2,"data":{"name":"7dtd","options":[{"name":"ip","options":[{"name":"add","options":[{"name":"address","value":"8.8.8.8"}]}]}]}}"#,
+        );
+        assert_eq!(
+            ApplicationCommandRoute::from_command_data(&data),
+            Some(ApplicationCommandRoute::SevenDaysIpAdd)
+        );
+        assert_eq!(
+            data.nested_subcommand_option_value("address")
+                .and_then(Value::as_str),
+            Some("8.8.8.8")
+        );
     }
 
     #[test]

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,3 +1,4 @@
 pub mod healthcheck;
 pub mod interaction_webhook;
 pub mod seven_days_gcp;
+pub mod seven_days_secret;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,5 +1,5 @@
 pub mod healthcheck;
 pub mod interaction_webhook;
 pub mod seven_days_gcp;
-pub mod seven_days_secret;
 pub mod seven_days_operation_lock;
+pub mod seven_days_secret;

--- a/src/services/seven_days_gcp.rs
+++ b/src/services/seven_days_gcp.rs
@@ -1,10 +1,11 @@
 use anyhow::{Context as _, Result};
 use reqwest::{Client, StatusCode};
-use serde::Deserialize;
-use std::time::Duration;
+use serde::{Deserialize, Serialize};
+use std::{net::Ipv4Addr, time::Duration};
 
 const METADATA_TOKEN_URL: &str =
     "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
+const MANAGED_FIREWALL_DESCRIPTION: &str = "Managed by zunda-bot-rs /7dtd ip";
 
 #[derive(Clone)]
 pub struct ComputeClient {
@@ -60,6 +61,40 @@ struct GuestAttributeResponse {
     variable_value: Option<String>,
 }
 
+#[derive(Deserialize)]
+struct FirewallListResponse {
+    #[serde(default)]
+    items: Vec<FirewallResponse>,
+}
+
+#[derive(Deserialize)]
+struct FirewallResponse {
+    name: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default, rename = "sourceRanges")]
+    source_ranges: Vec<String>,
+}
+
+#[derive(Serialize)]
+struct CreateFirewallRequest {
+    name: String,
+    description: &'static str,
+    network: String,
+    #[serde(rename = "sourceRanges")]
+    source_ranges: Vec<String>,
+    #[serde(rename = "targetTags")]
+    target_tags: Vec<String>,
+    allowed: Vec<FirewallAllowed>,
+}
+
+#[derive(Serialize)]
+struct FirewallAllowed {
+    #[serde(rename = "IPProtocol")]
+    ip_protocol: &'static str,
+    ports: Vec<&'static str>,
+}
+
 impl ComputeClient {
     pub fn new(project: String, zone: String, instance: String) -> Result<Self> {
         let http = Client::builder().timeout(Duration::from_secs(15)).build()?;
@@ -88,6 +123,13 @@ impl ComputeClient {
         format!(
             "https://compute.googleapis.com/compute/v1/projects/{}/zones/{}/instances/{}",
             self.project, self.zone, self.instance
+        )
+    }
+
+    fn firewalls_url(&self) -> String {
+        format!(
+            "https://compute.googleapis.com/compute/v1/projects/{}/global/firewalls",
+            self.project
         )
     }
 
@@ -153,6 +195,131 @@ impl ComputeClient {
         }
         Ok(())
     }
+
+    pub async fn allowed_ips(&self) -> Result<Vec<Ipv4Addr>> {
+        let response = self
+            .http
+            .get(self.firewalls_url())
+            .bearer_auth(self.token().await?)
+            .send()
+            .await?
+            .error_for_status()
+            .context("Compute Engine firewall list failed")?
+            .json::<FirewallListResponse>()
+            .await?;
+        let prefix = self.managed_firewall_prefix();
+        let mut ips = response
+            .items
+            .into_iter()
+            .filter(|rule| {
+                rule.name.starts_with(&prefix) && rule.description == MANAGED_FIREWALL_DESCRIPTION
+            })
+            .flat_map(|rule| rule.source_ranges)
+            .filter_map(|range| range.strip_suffix("/32").map(str::to_owned))
+            .filter_map(|address| address.parse().ok())
+            .collect::<Vec<Ipv4Addr>>();
+        ips.sort_unstable();
+        ips.dedup();
+        Ok(ips)
+    }
+
+    pub async fn add_allowed_ip(&self, ip: Ipv4Addr, network: &str) -> Result<bool> {
+        let request = CreateFirewallRequest {
+            name: self.managed_firewall_name(ip),
+            description: MANAGED_FIREWALL_DESCRIPTION,
+            network: format!("global/networks/{network}"),
+            source_ranges: vec![format!("{ip}/32")],
+            target_tags: vec![self.instance.clone()],
+            allowed: vec![
+                FirewallAllowed {
+                    ip_protocol: "tcp",
+                    ports: vec!["26900"],
+                },
+                FirewallAllowed {
+                    ip_protocol: "udp",
+                    ports: vec!["26900-26903"],
+                },
+            ],
+        };
+        let response = self
+            .http
+            .post(self.firewalls_url())
+            .bearer_auth(self.token().await?)
+            .json(&request)
+            .send()
+            .await?;
+        if response.status() == StatusCode::CONFLICT {
+            anyhow::ensure!(
+                self.managed_firewall_matches(ip).await?,
+                "firewall name is already used by an unmanaged rule"
+            );
+            return Ok(false);
+        }
+        response
+            .error_for_status()
+            .context("Compute Engine firewall creation failed")?;
+        Ok(true)
+    }
+
+    pub async fn remove_allowed_ip(&self, ip: Ipv4Addr) -> Result<bool> {
+        let name = self.managed_firewall_name(ip);
+        let Some(rule) = self.firewall(&name).await? else {
+            return Ok(false);
+        };
+        anyhow::ensure!(
+            is_managed_firewall_for_ip(&rule, ip),
+            "refusing to delete an unmanaged firewall rule"
+        );
+        let response = self
+            .http
+            .delete(format!("{}/{name}", self.firewalls_url()))
+            .bearer_auth(self.token().await?)
+            .send()
+            .await?;
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(false);
+        }
+        response
+            .error_for_status()
+            .context("Compute Engine firewall deletion failed")?;
+        Ok(true)
+    }
+
+    async fn managed_firewall_matches(&self, ip: Ipv4Addr) -> Result<bool> {
+        Ok(self
+            .firewall(&self.managed_firewall_name(ip))
+            .await?
+            .as_ref()
+            .is_some_and(|rule| is_managed_firewall_for_ip(rule, ip)))
+    }
+
+    async fn firewall(&self, name: &str) -> Result<Option<FirewallResponse>> {
+        let response = self
+            .http
+            .get(format!("{}/{name}", self.firewalls_url()))
+            .bearer_auth(self.token().await?)
+            .send()
+            .await?;
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        Ok(Some(
+            response
+                .error_for_status()
+                .context("Compute Engine firewall lookup failed")?
+                .json::<FirewallResponse>()
+                .await?,
+        ))
+    }
+
+    fn managed_firewall_prefix(&self) -> String {
+        let instance = self.instance.chars().take(47).collect::<String>();
+        format!("{instance}-player-")
+    }
+
+    fn managed_firewall_name(&self, ip: Ipv4Addr) -> String {
+        format!("{}{:08x}", self.managed_firewall_prefix(), u32::from(ip))
+    }
 }
 
 #[derive(Clone)]
@@ -215,6 +382,10 @@ fn parse_guest_runtime_state(value: &str) -> Result<GuestRuntimeState> {
     })
 }
 
+fn is_managed_firewall_for_ip(rule: &FirewallResponse, ip: Ipv4Addr) -> bool {
+    rule.description == MANAGED_FIREWALL_DESCRIPTION && rule.source_ranges == [format!("{ip}/32")]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -247,5 +418,32 @@ mod tests {
             }
         );
         assert!(parse_guest_runtime_state("READY|boot-id").is_err());
+    }
+
+    #[test]
+    fn creates_stable_managed_firewall_name() {
+        let client = ComputeClient::new("project".into(), "zone".into(), "zunda-7dtd".into())
+            .expect("client should build");
+        assert_eq!(
+            client.managed_firewall_name(Ipv4Addr::new(1, 2, 3, 4)),
+            "zunda-7dtd-player-01020304"
+        );
+    }
+
+    #[test]
+    fn only_matching_firewall_is_managed() {
+        let ip = Ipv4Addr::new(8, 8, 8, 8);
+        let managed = FirewallResponse {
+            name: "zunda-7dtd-player-08080808".into(),
+            description: MANAGED_FIREWALL_DESCRIPTION.into(),
+            source_ranges: vec!["8.8.8.8/32".into()],
+        };
+        assert!(is_managed_firewall_for_ip(&managed, ip));
+
+        let unmanaged = FirewallResponse {
+            description: "created manually".into(),
+            ..managed
+        };
+        assert!(!is_managed_firewall_for_ip(&unmanaged, ip));
     }
 }

--- a/src/services/seven_days_secret.rs
+++ b/src/services/seven_days_secret.rs
@@ -1,0 +1,129 @@
+use anyhow::{Context as _, Result};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use reqwest::Client;
+use serde::Deserialize;
+use std::time::Duration;
+
+const METADATA_TOKEN_URL: &str =
+    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
+
+#[derive(Clone)]
+pub struct SecretManagerClient {
+    http: Client,
+    project: String,
+    secret: String,
+}
+
+#[derive(Deserialize)]
+struct AccessToken {
+    access_token: String,
+}
+
+#[derive(Deserialize)]
+struct SecretAccessResponse {
+    payload: SecretPayload,
+}
+
+#[derive(Deserialize)]
+struct SecretPayload {
+    data: String,
+}
+
+impl SecretManagerClient {
+    pub fn new(project: String, secret: String) -> Result<Self> {
+        anyhow::ensure!(valid_project_id(&project), "invalid GCP project id");
+        anyhow::ensure!(valid_secret_id(&secret), "invalid Secret Manager secret id");
+        Ok(Self {
+            http: Client::builder().timeout(Duration::from_secs(15)).build()?,
+            project,
+            secret,
+        })
+    }
+
+    pub async fn latest(&self) -> Result<String> {
+        let response = self
+            .http
+            .get(format!(
+                "https://secretmanager.googleapis.com/v1/projects/{}/secrets/{}/versions/latest:access",
+                self.project, self.secret
+            ))
+            .bearer_auth(self.token().await?)
+            .send()
+            .await?
+            .error_for_status()
+            .context("7DTD server password lookup failed")?
+            .json::<SecretAccessResponse>()
+            .await?;
+        decode_server_password(&response)
+    }
+
+    async fn token(&self) -> Result<String> {
+        Ok(self
+            .http
+            .get(METADATA_TOKEN_URL)
+            .header("Metadata-Flavor", "Google")
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<AccessToken>()
+            .await?
+            .access_token)
+    }
+}
+
+fn decode_server_password(response: &SecretAccessResponse) -> Result<String> {
+    let decoded = STANDARD
+        .decode(&response.payload.data)
+        .context("7DTD server password was not valid base64")?;
+    let password = String::from_utf8(decoded)
+        .context("7DTD server password was not UTF-8")?
+        .trim()
+        .to_owned();
+    anyhow::ensure!(
+        !password.is_empty()
+            && password.len() <= 128
+            && password.chars().all(|character| character.is_ascii()
+                && !character.is_control()
+                && character != '`'),
+        "7DTD server password contains unsupported characters"
+    );
+    Ok(password)
+}
+
+fn valid_project_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.chars().all(|character| {
+            character.is_ascii_lowercase() || character.is_ascii_digit() || character == '-'
+        })
+}
+
+fn valid_secret_id(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_'))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_generated_server_password() {
+        let response: SecretAccessResponse =
+            serde_json::from_str(r#"{"payload":{"data":"MDEyMzQ1Njc4OWFiY2RlZg=="}}"#)
+                .expect("response should parse");
+        assert_eq!(
+            decode_server_password(&response).expect("password should decode"),
+            "0123456789abcdef"
+        );
+    }
+
+    #[test]
+    fn rejects_password_that_could_change_discord_markup() {
+        let response: SecretAccessResponse =
+            serde_json::from_str(r#"{"payload":{"data":"cGFzc3dvcmRg"}}"#)
+                .expect("response should parse");
+        assert!(decode_server_password(&response).is_err());
+    }
+}

--- a/src/usecase/seven_days_usecase.rs
+++ b/src/usecase/seven_days_usecase.rs
@@ -7,7 +7,6 @@ use anyhow::{Context as _, Result};
 use chrono::{DateTime, Utc};
 use sqlx::PgPool;
 use std::{collections::HashSet, env, net::Ipv4Addr, sync::Arc, time::Duration};
-use tokio::net::TcpStream;
 use tokio::time::Instant;
 
 const START_TIMEOUT: Duration = Duration::from_secs(10 * 60);

--- a/src/usecase/seven_days_usecase.rs
+++ b/src/usecase/seven_days_usecase.rs
@@ -1,6 +1,7 @@
 use crate::services::seven_days_gcp::{
     ComputeClient, DuckDnsClient, GuestRuntimeState, InstanceStatus,
 };
+use crate::services::seven_days_secret::SecretManagerClient;
 use anyhow::{Context as _, Result};
 use chrono::{DateTime, Utc};
 use std::{collections::HashSet, env, net::Ipv4Addr, time::Duration};
@@ -18,6 +19,7 @@ pub struct SevenDaysUsecase {
     port: u16,
     network: String,
     max_allowed_ips: usize,
+    server_password: SecretManagerClient,
     auth: Authorization,
 }
 
@@ -67,6 +69,11 @@ impl SevenDaysUsecase {
         };
         let parse = |name: &str| -> Result<i64> { Ok(required(name)?.parse()?) };
         let (duckdns_subdomain, domain) = duckdns_names(&required("SEVEN_DAYS_DUCKDNS_DOMAIN")?)?;
+        let server_password = SecretManagerClient::new(
+            project.clone(),
+            optional_env("SEVEN_DAYS_SERVER_PASSWORD_SECRET_ID")
+                .unwrap_or_else(|| "SEVEN_DAYS_SERVER_PASSWORD".into()),
+        )?;
         Ok(Some(Self {
             compute: ComputeClient::new(
                 project,
@@ -82,6 +89,7 @@ impl SevenDaysUsecase {
             max_allowed_ips: optional_env("SEVEN_DAYS_MAX_ALLOWED_IPS")
                 .unwrap_or_else(|| "16".into())
                 .parse()?,
+            server_password,
             auth: Authorization {
                 guild_id: parse("SEVEN_DAYS_DISCORD_GUILD_ID")?,
                 channel_id: parse("SEVEN_DAYS_DISCORD_CHANNEL_ID")?,
@@ -188,19 +196,28 @@ impl SevenDaysUsecase {
     pub async fn add_allowed_ip(&self, value: &str) -> Result<String> {
         let ip = allowed_ipv4(value)?;
         let current = self.compute.allowed_ips().await?;
-        if current.contains(&ip) {
-            return Ok("そのIPはすでに許可されているのだ。".into());
+        let already_allowed = current.contains(&ip);
+        if !already_allowed {
+            anyhow::ensure!(
+                current.len() < self.max_allowed_ips,
+                "allowed IP limit ({}) was reached",
+                self.max_allowed_ips
+            );
         }
-        anyhow::ensure!(
-            current.len() < self.max_allowed_ips,
-            "allowed IP limit ({}) was reached",
-            self.max_allowed_ips
-        );
-        if self.compute.add_allowed_ip(ip, &self.network).await? {
-            Ok(format!("`{ip}` を接続許可IPへ追加したのだ。"))
+        // Firewallを変更する前に取得し、パスワードを表示できない中途半端な成功を避ける。
+        let password = self.server_password.latest().await?;
+        let added = if already_allowed {
+            false
         } else {
-            Ok("そのIPはすでに許可されているのだ。".into())
-        }
+            self.compute.add_allowed_ip(ip, &self.network).await?
+        };
+        Ok(format_allowed_ip_add(
+            ip,
+            &self.domain,
+            self.port,
+            &password,
+            added,
+        ))
     }
 
     pub async fn remove_allowed_ip(&self, value: &str) -> Result<String> {
@@ -290,6 +307,23 @@ fn allowed_ipv4(value: &str) -> Result<Ipv4Addr> {
         .context("address must be an IPv4 address")?;
     anyhow::ensure!(is_global_ipv4(ip), "address must be a global IPv4 address");
     Ok(ip)
+}
+
+fn format_allowed_ip_add(
+    ip: Ipv4Addr,
+    domain: &str,
+    port: u16,
+    password: &str,
+    added: bool,
+) -> String {
+    let result = if added {
+        format!("`{ip}` を接続許可IPへ追加したのだ。")
+    } else {
+        "そのIPはすでに許可されているのだ。".into()
+    };
+    format!(
+        "{result}\n接続先: `{domain}:{port}`\nサーバーパスワード: `{password}`\n※管理者だけが受け取るエフェメラル応答なのだ。"
+    )
 }
 
 fn is_global_ipv4(ip: Ipv4Addr) -> bool {
@@ -420,5 +454,19 @@ mod tests {
         ] {
             assert!(allowed_ipv4(address).is_err(), "{address} must be rejected");
         }
+    }
+
+    #[test]
+    fn formats_password_after_allowed_ip_add() {
+        assert_eq!(
+            format_allowed_ip_add(
+                Ipv4Addr::new(8, 8, 8, 8),
+                "zunda-7dtd.duckdns.org",
+                26900,
+                "0123456789abcdef",
+                true,
+            ),
+            "`8.8.8.8` を接続許可IPへ追加したのだ。\n接続先: `zunda-7dtd.duckdns.org:26900`\nサーバーパスワード: `0123456789abcdef`\n※管理者だけが受け取るエフェメラル応答なのだ。"
+        );
     }
 }

--- a/src/usecase/seven_days_usecase.rs
+++ b/src/usecase/seven_days_usecase.rs
@@ -3,7 +3,7 @@ use crate::services::seven_days_gcp::{
 };
 use anyhow::{Context as _, Result};
 use chrono::{DateTime, Utc};
-use std::{collections::HashSet, env, time::Duration};
+use std::{collections::HashSet, env, net::Ipv4Addr, time::Duration};
 use tokio::time::Instant;
 
 const START_TIMEOUT: Duration = Duration::from_secs(10 * 60);
@@ -16,6 +16,8 @@ pub struct SevenDaysUsecase {
     duckdns: DuckDnsClient,
     domain: String,
     port: u16,
+    network: String,
+    max_allowed_ips: usize,
     auth: Authorization,
 }
 
@@ -75,6 +77,10 @@ impl SevenDaysUsecase {
             domain,
             port: optional_env("SEVEN_DAYS_PORT")
                 .unwrap_or_else(|| "26900".into())
+                .parse()?,
+            network: optional_env("SEVEN_DAYS_GCP_NETWORK").unwrap_or_else(|| "default".into()),
+            max_allowed_ips: optional_env("SEVEN_DAYS_MAX_ALLOWED_IPS")
+                .unwrap_or_else(|| "16".into())
                 .parse()?,
             auth: Authorization {
                 guild_id: parse("SEVEN_DAYS_DISCORD_GUILD_ID")?,
@@ -164,6 +170,48 @@ impl SevenDaysUsecase {
         Ok("安全停止はまだ処理中なのだ。`/7dtd status` で停止完了を確認してほしいのだ。".into())
     }
 
+    pub async fn list_allowed_ips(&self) -> Result<String> {
+        let ips = self.compute.allowed_ips().await?;
+        if ips.is_empty() {
+            return Ok("Bot が管理する接続許可IPはないのだ。".into());
+        }
+        Ok(format!(
+            "接続許可IPなのだ（{}件）:\n{}",
+            ips.len(),
+            ips.iter()
+                .map(|ip| format!("- `{ip}`"))
+                .collect::<Vec<String>>()
+                .join("\n")
+        ))
+    }
+
+    pub async fn add_allowed_ip(&self, value: &str) -> Result<String> {
+        let ip = allowed_ipv4(value)?;
+        let current = self.compute.allowed_ips().await?;
+        if current.contains(&ip) {
+            return Ok("そのIPはすでに許可されているのだ。".into());
+        }
+        anyhow::ensure!(
+            current.len() < self.max_allowed_ips,
+            "allowed IP limit ({}) was reached",
+            self.max_allowed_ips
+        );
+        if self.compute.add_allowed_ip(ip, &self.network).await? {
+            Ok(format!("`{ip}` を接続許可IPへ追加したのだ。"))
+        } else {
+            Ok("そのIPはすでに許可されているのだ。".into())
+        }
+    }
+
+    pub async fn remove_allowed_ip(&self, value: &str) -> Result<String> {
+        let ip = allowed_ipv4(value)?;
+        if self.compute.remove_allowed_ip(ip).await? {
+            Ok(format!("`{ip}` を接続許可IPから削除したのだ。"))
+        } else {
+            Ok("そのIPはすでに許可されていないのだ。".into())
+        }
+    }
+
     async fn runtime_ready(&self, status: &InstanceStatus) -> Result<bool> {
         let Some(runtime) = self.compute.guest_runtime_state().await? else {
             return Ok(false);
@@ -231,6 +279,38 @@ fn guest_runtime_is_current_and_ready(
         return false;
     };
     runtime_started >= instance_started
+}
+
+fn allowed_ipv4(value: &str) -> Result<Ipv4Addr> {
+    let value = value.trim();
+    let ip = value
+        .strip_suffix("/32")
+        .unwrap_or(value)
+        .parse::<Ipv4Addr>()
+        .context("address must be an IPv4 address")?;
+    anyhow::ensure!(is_global_ipv4(ip), "address must be a global IPv4 address");
+    Ok(ip)
+}
+
+fn is_global_ipv4(ip: Ipv4Addr) -> bool {
+    let [first, second, third, _] = ip.octets();
+    !matches!(
+        (first, second, third),
+        (0, _, _)
+            | (10, _, _)
+            | (100, 64..=127, _)
+            | (127, _, _)
+            | (169, 254, _)
+            | (172, 16..=31, _)
+            | (192, 0, 0)
+            | (192, 0, 2)
+            | (192, 88, 99)
+            | (192, 168, _)
+            | (198, 18..=19, _)
+            | (198, 51, 100)
+            | (203, 0, 113)
+            | (224..=255, _, _)
+    )
 }
 
 #[cfg(test)]
@@ -322,5 +402,23 @@ mod tests {
             ..current
         };
         assert!(!guest_runtime_is_current_and_ready(&status, &stale));
+    }
+
+    #[test]
+    fn accepts_only_global_ipv4_addresses() {
+        assert_eq!(
+            allowed_ipv4("8.8.8.8/32").expect("public IPv4 should be accepted"),
+            Ipv4Addr::new(8, 8, 8, 8)
+        );
+        for address in [
+            "10.0.0.1",
+            "127.0.0.1",
+            "169.254.1.1",
+            "192.0.2.1",
+            "224.0.0.1",
+            "255.255.255.255",
+        ] {
+            assert!(allowed_ipv4(address).is_err(), "{address} must be rejected");
+        }
     }
 }

--- a/src/usecase/seven_days_usecase.rs
+++ b/src/usecase/seven_days_usecase.rs
@@ -1,8 +1,8 @@
 use crate::services::seven_days_gcp::{
     ComputeClient, DuckDnsClient, GuestRuntimeState, InstanceStatus,
 };
-use crate::services::seven_days_secret::SecretManagerClient;
 use crate::services::seven_days_operation_lock::SevenDaysOperationLock;
+use crate::services::seven_days_secret::SecretManagerClient;
 use anyhow::{Context as _, Result};
 use chrono::{DateTime, Utc};
 use sqlx::PgPool;


### PR DESCRIPTION
## 概要

- Issue #44: Discordから7DTDの接続許可IPを管理
- 管理者限定の `/7dtd ip list|add|remove` を追加
- `ip add`成功時に接続先とゲームサーバーパスワードをエフェメラル表示
- IPごとのBot管理Firewall ruleで同時操作の上書きを回避

## 作業内容

- `/7dtd ip` subcommand groupをglobal commandへ登録し、全IP操作を管理者限定化
- グローバルIPv4の検証と`/32`正規化を追加
- private、loopback、link-local、documentation、benchmark、multicast、予約範囲を拒否
- Bot管理ruleの一覧・作成・削除をCompute Engine APIへ追加
- rule名をinstance名とIPv4の16進表現から決定し、add/removeを冪等化
- descriptionとsource rangeが一致しないruleは削除しない
- 登録上限を環境変数で設定
- ゲームサーバーパスワード専用SecretとSecret Manager APIをTerraformへ追加
- VMには専用Secretへのversion追加、Cloud Runには同Secretの読み取りだけを付与
- VM内で生成したパスワードを引数・metadata・ログ・Terraform stateへ載せず専用Secretへ同期
- BotがFirewall作成前にパスワードを取得し、接続先とともにエフェメラル応答へ表示
- README、Runbook、Terraform README、UMLを同期

## 作業意図

- 回線のIPv4変更時にTerraformの手動変更を待たず接続を復旧するため
- IP追加後、管理者が同じ応答から接続先とパスワードを案内できるようにするため
- パスワード取得失敗時にFirewallだけが追加される中途半端な成功を防ぐため
- 単一ruleのsourceRanges配列更新による同時操作のlost updateを避けるため
- Terraform管理ruleや手動作成ruleをBotが変更しないようにするため
- パスワードをGuest Attributesなどの平文参照経路へ置かず、専用Secretの最小IAMに限定するため

## 手動で次にするべき作業

- Terraform planでSecret Manager API、専用Secret、Secret単位IAM、Firewall権限を確認する
- Terraform apply後、既存VMは一度起動してパスワードを専用Secretへ同期する
- output `server_password_secret_id`に有効なversionが作られたことを、値をログへ出さず確認する
- 一般ユーザーでstart/stop/ip操作が拒否され、statusだけ許可されることを確認する
- 管理者の`/7dtd ip add`でIP、接続先、ゲームサーバーパスワードがエフェメラル表示されることを確認する
- add後にTCP 26900／UDP 26900-26903へ対象IPから接続する
- remove後に対象IPから接続できないことを確認する

## 変更ファイル

- `Cargo.toml`
- `README.md`
- `docs/seven-days-server.md`
- `docs/uml/seven-days-server.puml`
- `infra/seven-days/install.sh`
- `infra/terraform/seven-days-server/README.md`
- `infra/terraform/seven-days-server/main.tf`
- `infra/terraform/seven-days-server/outputs.tf`
- `infra/terraform/seven-days-server/terraform.tfvars.example`
- `infra/terraform/seven-days-server/variables.tf`
- `src/main.rs`
- `src/services/interaction_webhook.rs`
- `src/services/mod.rs`
- `src/services/seven_days_gcp.rs`
- `src/services/seven_days_secret.rs`
- `src/usecase/seven_days_usecase.rs`

## テスト結果

- `cargo fmt --check`: 成功
- `cargo clippy --all-targets --all-features -- -D warnings`: 成功（macOS SDKのclangを明示）
- `cargo test`: 43件成功（macOS SDKのclangを明示）
- `bash -n infra/seven-days/install.sh`: 成功
- `terraform fmt -check main.tf variables.tf outputs.tf`: 成功
- `terraform validate`: 成功
- GitHub Actions `quality-gate`: 成功

## 制限事項

- Compute Engine operation完了前にAPI受付結果をDiscordへ返すため、rule反映には短い遅延があり得る
- Cloud Runが複数instanceで同時に異なるIPを追加した場合、上限件数を一時的に超える可能性がある。ただしIP別ruleのため既存許可は失わない
- エフェメラル応答も管理者がコピー・転送できるため、管理者ID・Roleは必要最小限にする
- Discordのinline codeを壊す制御文字とbacktickを含む既存パスワードは表示せず、Firewallも追加しない
- IPv6は対象外
- PR #46を先にマージするstacked PR
- Secret連携と既存VM移行を含むIssue明示の広いscopeのため、推奨300行を超えている

Closes #44
