### PR TITLE
7DTD停止時に月次・年次のGCP利用料金を表示する

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ gcloud run services describe zunda-bot-rs \
 
 ## 7 Days to Die サーバー
 
-許可された Discord Guild／Channel／User・Role から `/7dtd start`、`/7dtd status`、管理者の `/7dtd stop` を実行できる。VM内で確認したゲームポートのREADY状態はGuest Attributes経由でBotへ通知する。GCP 構築、Cloud Run 環境変数、セーブ移行、安全停止、backup／復元は Runbook を参照する。
+許可された Discord Guild／Channel／User・Role から `/7dtd start`、`/7dtd status`、管理者の `/7dtd stop` を実行できる。VM内で確認したゲームポートのREADY状態はGuest Attributes経由でBotへ通知し、停止完了時にはCloud Billing exportに反映済みの月次・年次料金を表示する。GCP 構築、Cloud Run 環境変数、セーブ移行、安全停止、料金表示、backup／復元は Runbook を参照する。
 READY までの非同期処理を確実に完了させるため、初期構成では Runbook 記載の Cloud Run CPU 設定が必要になる。
 
 ## デバッグ

--- a/docs/seven-days-server.md
+++ b/docs/seven-days-server.md
@@ -2,14 +2,15 @@
 
 ## 構成と初期構築
 
-`infra/terraform/seven-days-server` を apply すると、東京リージョンの `e2-standard-4` VM、テスト用 10 GiB の分離 Persistent Disk、東京リージョンの GCS バックアップバケット、ゲーム用 firewall、Cloud Run 用 custom role、DuckDNS Secret の IAM、Budget Alert を作成する。外部 IPv4 は一時アドレスであり、停止中も Persistent Disk と GCS の保存料金は発生する。GCS バケットは既定で 30 日を過ぎたバックアップを自動削除する。継続運用では `data_disk_size_gb=20` 以上を推奨する。
+`infra/terraform/seven-days-server` を apply すると、東京リージョンの `e2-standard-4` VM、テスト用 10 GiB の分離 Persistent Disk、東京リージョンの GCS バックアップバケット、Cloud Billing export用BigQuery dataset、ゲーム用 firewall、Cloud Run 用 custom role、DuckDNS Secret の IAM、Budget Alert を作成する。外部 IPv4 は一時アドレスであり、停止中も Persistent Disk、GCS、BigQueryなどの料金は発生する。GCS バケットは既定で 30 日を過ぎたバックアップを自動削除する。継続運用では `data_disk_size_gb=20` 以上を推奨する。
 
 1. Secret Manager に `SEVEN_DAYS_DUCKDNS_TOKEN` を登録する。ゲームサーバーと Telnet のパスワードは初回起動時に VM 内で生成するため、tfvars や state には入れない。
 2. Terraform README に従い versioning 有効な state bucket を bootstrap し、必要なら `backup_bucket_name` を指定して apply する。バックアップ用バケットは Terraform が作成する。
    既存の 80 GiB データディスクは縮小できないため、既存環境では移行完了まで `data_disk_size_gb=80` を明示する。新しい 10 GiB ディスクへのコピーと短時間の起動確認を終えてから、ディスク参照を切り替える。継続運用へ移る場合は20GiB以上へ拡張する。
 3. 初回起動時に startup script が `/srv/seven-days-data/serverconfig.xml` の `CHANGE_BEFORE_START` をランダム値へ置換する。ゲーム用と Telnet 用の値は、それぞれ root のみ読める `/srv/seven-days-data/server-password` と `/srv/seven-days-data/telnet-password` にも保存する。値を shell history やログへ出さない。
 4. startup script がゲームサーバーを起動し、TCP 26900 の待受を確認してから Guest Attributes に起動時刻付きの READY を通知し、プロビジョニング完了とする。`serverconfig.xml` にプレースホルダーが残る場合は systemd の起動条件でも拒否する。起動後に service の状態と journal を確認し、以後は VM 起動時に自動起動する。
-5. Cloud Run に下記環境変数を設定し、DuckDNS token だけを Secret Manager から注入する。
+5. Terraform apply後、Cloud Billing ConsoleでStandard usage cost exportを有効化し、出力された `billing_export_dataset` を保存先に指定する。作成される `gcp_billing_export_v1_...` table名を確認する。exportには反映遅延があり、初回backfill完了まで数日かかる場合がある。
+6. Cloud Run に下記環境変数を設定し、DuckDNS token だけを Secret Manager から注入する。
 
 ```text
 SEVEN_DAYS_GCP_PROJECT, SEVEN_DAYS_GCP_ZONE, SEVEN_DAYS_GCP_INSTANCE
@@ -17,9 +18,12 @@ SEVEN_DAYS_DUCKDNS_DOMAIN, SEVEN_DAYS_DUCKDNS_TOKEN, SEVEN_DAYS_PORT
 SEVEN_DAYS_DISCORD_GUILD_ID, SEVEN_DAYS_DISCORD_CHANNEL_ID
 SEVEN_DAYS_DISCORD_USER_IDS, SEVEN_DAYS_DISCORD_ROLE_IDS
 SEVEN_DAYS_DISCORD_ADMIN_USER_IDS, SEVEN_DAYS_DISCORD_ADMIN_ROLE_IDS
+SEVEN_DAYS_BILLING_PROJECT, SEVEN_DAYS_BILLING_DATASET, SEVEN_DAYS_BILLING_TABLE
+SEVEN_DAYS_BILLING_MAX_BYTES
 ```
 
 ID のリストはカンマ区切り。一般 ID は start/status、管理 ID は start/status/stop を実行できる。
+Billing projectは未指定なら `SEVEN_DAYS_GCP_PROJECT`、1回のquery上限は未指定なら100 MB。datasetを指定しない場合は料金表示を無効化する。
 
 ゲームサーバーは身内の 2〜4 人だけで利用する。`game_source_ranges` には参加者の固定 IPv4 を `/32` で指定し、ゲーム用ポートへの接続元を限定する。VPN は利用しない。自宅回線の IP が変わった場合は、Terraform の値を更新して再 apply する。SSH などの管理用ポートを全世界へ公開しない。
 
@@ -36,7 +40,7 @@ ID のリストはカンマ区切り。一般 ID は start/status、管理 ID �
 
 - `/7dtd start`: TERMINATED の場合だけ起動し、外部 IPv4 を DuckDNS に登録して、VM 内で TCP 26900 を確認した現在の起動の READY 通知を待つ。
 - `/7dtd status`: VM、Guest Attributes上のゲーム状態、ポート、domain、外部 IPv4、稼働時間を表示する。
-- `/7dtd stop`: Compute Engine の通常停止を要求する。systemd `ExecStop` がゲーム内通知、`saveworld`、`shutdown`、プロセス終了確認を通常停止猶予内に行い、Botは最大2分停止完了を待つ。
+- `/7dtd stop`: Compute Engine の通常停止を要求する。systemd `ExecStop` がゲーム内通知、`saveworld`、`shutdown`、プロセス終了確認を通常停止猶予内に行い、Botは最大2分停止完了を待つ。停止完了後、Billing exportに反映済みの当月・当年net cost、通貨、集計反映時点を表示する。料金取得失敗は停止結果を失敗へ変更しない。
 - READY にならない場合は serial/startup logs、`systemctl status seven-days`、`journalctl -u seven-days`、firewall、`serverconfig.xml` を確認する。
 - DuckDNS 失敗時は Secret の version と Cloud Run service account の accessor IAM を確認する。token を URL やログに貼らない。
 - stop が完了しない場合は VM を強制停止せず journal と telnet password file を確認し、ゲーム内で保存後に再試行する。

--- a/docs/uml/seven-days-server.puml
+++ b/docs/uml/seven-days-server.puml
@@ -8,11 +8,19 @@ participant "7DTD VM\nsystemd" as VM
 database "Persistent Disk" as Disk
 cloud "Cloud Storage\nbackup bucket" as Storage
 database "BigQuery\nBilling export" as Billing
+database "PostgreSQL\noperation lock" as OperationLock
 User -> Discord: /7dtd start|status|stop
 Discord -> Bot: signed interaction
 Bot -> Bot: Guild/Channel/User/Role authorization
+Bot -> OperationLock: pg_try_advisory_xact_lock (start/stop)
+alt another start/stop is running
+  OperationLock --> Bot: false
+  Bot --> Discord: 使用中メッセージ（VM APIを呼ばない）
+  break no operation
+else lock acquired
 Bot -> Compute: get/start/stop
 Compute -> VM: power lifecycle
+end
 Bot -> DuckDNS: update temporary IPv4
 VM -> VM: TCP 26900 readiness
 VM -> Compute: Guest Attributes READY

--- a/docs/uml/seven-days-server.puml
+++ b/docs/uml/seven-days-server.puml
@@ -7,6 +7,7 @@ participant DuckDNS
 participant "7DTD VM\nsystemd" as VM
 database "Persistent Disk" as Disk
 cloud "Cloud Storage\nbackup bucket" as Storage
+database "BigQuery\nBilling export" as Billing
 User -> Discord: /7dtd start|status|stop
 Discord -> Bot: signed interaction
 Bot -> Bot: Guild/Channel/User/Role authorization
@@ -19,5 +20,6 @@ Bot -> Compute: current boot READY lookup
 VM -> Disk: Saves / GeneratedWorlds / Mods
 VM -> Disk: saveworld before shutdown
 VM -> Storage: compressed backup upload
+Bot -> Billing: monthly/yearly net cost after stop
 Bot --> Discord: ephemeral followup
 @enduml

--- a/infra/terraform/seven-days-server/README.md
+++ b/infra/terraform/seven-days-server/README.md
@@ -18,6 +18,8 @@ terraform apply /tmp/seven-days-server.tfplan
 
 `backup_bucket_name` を空のままにすると、`<project_id>-<instance_name>-backups` という名前でバックアップ用バケットを作成する。バケットは東京リージョンの Standard Storage、30日後削除のライフサイクル、公開アクセス禁止で構成される。`backup_retention_days` で保持日数を変更できる。
 
+apply後、Cloud Billing ConsoleのBigQuery exportでStandard usage costを有効化し、output `billing_export_dataset` のdatasetを保存先に指定する。TerraformはdatasetとCloud Runの読み取りIAMを作成するが、Billing Account側のexport有効化は行わない。作成されたtable名をCloud Runの `SEVEN_DAYS_BILLING_TABLE` へ設定する。初回反映と通常の利用料金反映には遅延がある。
+
 既存の Persistent Disk は容量を縮小できないため、既存の 80 GiB ディスクへこの設定をそのまま apply しない。既存環境では、移行作業が完了するまで `data_disk_size_gb=80` を明示し、別の 10 GiB ディスクへゲームデータをコピーして短時間の動作確認をした後、Terraform のディスク参照を計画的に切り替える。継続運用へ移る場合は20GiB以上へ拡張する。
 
 state bucket の IAM は Terraform 実行者だけに限定する。VM のデフォルトサービスアカウントには、バックアップ用バケットへのオブジェクト作成権限だけを付与する。`terraform destroy` は data disk の `prevent_destroy` により失敗する設計であり、データディスクを明示的に state から外すなどの人手確認なしに解除しない。

--- a/infra/terraform/seven-days-server/main.tf
+++ b/infra/terraform/seven-days-server/main.tf
@@ -38,6 +38,38 @@ resource "google_storage_bucket_iam_member" "backup_writer" {
   member = "serviceAccount:${data.google_project.current.number}-compute@developer.gserviceaccount.com"
 }
 
+# 7DTDプロジェクトの料金をCloud Billing exportから読み取るためのBigQuery基盤。
+# Billing export自体はCloud Billing Consoleでこのdatasetを選択して有効化する。
+resource "google_project_service" "bigquery" {
+  project            = var.project_id
+  service            = "bigquery.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_bigquery_dataset" "billing_export" {
+  project                    = var.project_id
+  dataset_id                 = var.billing_export_dataset_id
+  friendly_name              = "7DTD billing export"
+  description                = "Cloud Billing standard usage cost export for the 7DTD project"
+  location                   = var.billing_export_location
+  delete_contents_on_destroy = false
+  depends_on                 = [google_project_service.bigquery]
+}
+
+# Query jobの作成権限と、上記datasetだけの読み取り権限をCloud Runへ付与する。
+resource "google_project_iam_member" "cloud_run_bigquery_job_user" {
+  project = var.project_id
+  role    = "roles/bigquery.jobUser"
+  member  = "serviceAccount:${var.cloud_run_service_account_email}"
+}
+
+resource "google_bigquery_dataset_iam_member" "cloud_run_billing_viewer" {
+  project    = var.project_id
+  dataset_id = google_bigquery_dataset.billing_export.dataset_id
+  role       = "roles/bigquery.dataViewer"
+  member     = "serviceAccount:${var.cloud_run_service_account_email}"
+}
+
 # 7DTD のゲーム通信だけを許可するファイアウォール。
 # source_ranges は参加者の固定 IP (/32) を指定することを想定する。
 # 0.0.0.0/0 を使う場合でも、ここで指定したゲームポート以外は公開しない。

--- a/infra/terraform/seven-days-server/outputs.tf
+++ b/infra/terraform/seven-days-server/outputs.tf
@@ -9,3 +9,6 @@ output "backup_bucket" { value = google_storage_bucket.backup.name }
 
 # Cloud Run の VM 操作用サービスアカウントへ付与したカスタムロール名。
 output "cloud_run_custom_role" { value = google_project_iam_custom_role.operator.name }
+
+# Cloud Billing ConsoleでStandard usage cost exportの保存先に指定するdataset。
+output "billing_export_dataset" { value = google_bigquery_dataset.billing_export.dataset_id }

--- a/infra/terraform/seven-days-server/terraform.tfvars.example
+++ b/infra/terraform/seven-days-server/terraform.tfvars.example
@@ -2,3 +2,4 @@ project_id = "your-project"
 cloud_run_service_account_email = "zunda-bot@your-project.iam.gserviceaccount.com"
 billing_account_id = "000000-000000-000000"
 game_source_ranges = ["203.0.113.10/32"]
+billing_export_dataset_id = "billing_export"

--- a/infra/terraform/seven-days-server/variables.tf
+++ b/infra/terraform/seven-days-server/variables.tf
@@ -44,6 +44,18 @@ variable "backup_retention_days" {
   default = 30
 }
 
+# Cloud BillingのStandard usage cost exportを保存するBigQuery dataset。
+variable "billing_export_dataset_id" {
+  type    = string
+  default = "billing_export"
+}
+
+# 初回有効化時に前月からのbackfillを利用できるUS multi-regionを既定とする。
+variable "billing_export_location" {
+  type    = string
+  default = "US"
+}
+
 # VM とファイアウォールを配置する VPC ネットワーク。
 variable "network" {
   type    = string

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,3 +1,4 @@
 pub mod healthcheck;
 pub mod interaction_webhook;
+pub mod seven_days_billing;
 pub mod seven_days_gcp;

--- a/src/services/seven_days_billing.rs
+++ b/src/services/seven_days_billing.rs
@@ -1,0 +1,239 @@
+use anyhow::{Context as _, Result};
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::{json, Value};
+use std::time::Duration;
+
+const METADATA_TOKEN_URL: &str =
+    "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token";
+
+#[derive(Clone)]
+pub struct BillingClient {
+    http: Client,
+    query_project: String,
+    dataset: String,
+    table: String,
+    cost_project: String,
+    maximum_bytes_billed: u64,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct CostSummary {
+    pub monthly: f64,
+    pub yearly: f64,
+    pub currency: String,
+    pub exported_at: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct AccessToken {
+    access_token: String,
+}
+
+#[derive(Deserialize)]
+struct QueryResponse {
+    #[serde(default, rename = "jobComplete")]
+    job_complete: bool,
+    #[serde(default)]
+    rows: Vec<QueryRow>,
+}
+
+#[derive(Deserialize)]
+struct QueryRow {
+    f: Vec<QueryCell>,
+}
+
+#[derive(Deserialize)]
+struct QueryCell {
+    v: Option<String>,
+}
+
+impl BillingClient {
+    pub fn new(
+        query_project: String,
+        dataset: String,
+        table: String,
+        cost_project: String,
+        maximum_bytes_billed: u64,
+    ) -> Result<Self> {
+        anyhow::ensure!(
+            valid_project_id(&query_project),
+            "invalid billing project id"
+        );
+        anyhow::ensure!(valid_bigquery_id(&dataset), "invalid billing dataset id");
+        anyhow::ensure!(valid_bigquery_id(&table), "invalid billing table id");
+        let http = Client::builder().timeout(Duration::from_secs(20)).build()?;
+        Ok(Self {
+            http,
+            query_project,
+            dataset,
+            table,
+            cost_project,
+            maximum_bytes_billed,
+        })
+    }
+
+    pub async fn costs(&self) -> Result<CostSummary> {
+        let response = self
+            .http
+            .post(format!(
+                "https://bigquery.googleapis.com/bigquery/v2/projects/{}/queries",
+                self.query_project
+            ))
+            .bearer_auth(self.token().await?)
+            .json(&self.query_request())
+            .send()
+            .await?
+            .error_for_status()
+            .context("BigQuery billing query failed")?
+            .json::<QueryResponse>()
+            .await?;
+        anyhow::ensure!(
+            response.job_complete,
+            "BigQuery billing query did not finish"
+        );
+        parse_cost_summary(&response)
+    }
+
+    async fn token(&self) -> Result<String> {
+        Ok(self
+            .http
+            .get(METADATA_TOKEN_URL)
+            .header("Metadata-Flavor", "Google")
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<AccessToken>()
+            .await?
+            .access_token)
+    }
+
+    fn query_request(&self) -> Value {
+        json!({
+            "query": self.query(),
+            "useLegacySql": false,
+            "parameterMode": "NAMED",
+            "queryParameters": [{
+                "name": "cost_project",
+                "parameterType": { "type": "STRING" },
+                "parameterValue": { "value": self.cost_project }
+            }],
+            "maximumBytesBilled": self.maximum_bytes_billed.to_string(),
+            "timeoutMs": 10_000
+        })
+    }
+
+    fn query(&self) -> String {
+        format!(
+            r#"SELECT
+  COALESCE(SUM(IF(usage_start_time >= TIMESTAMP(DATE_TRUNC(CURRENT_DATE("Asia/Tokyo"), MONTH), "Asia/Tokyo"), net_cost, 0)), 0) AS monthly_cost,
+  COALESCE(SUM(net_cost), 0) AS yearly_cost,
+  ANY_VALUE(currency) AS currency,
+  MAX(export_time) AS exported_at
+FROM (
+  SELECT usage_start_time, export_time, currency,
+    cost + IFNULL((SELECT SUM(credit.amount) FROM UNNEST(credits) AS credit), 0) AS net_cost
+  FROM `{}.{}.{}`
+  WHERE project.id = @cost_project
+    AND usage_start_time >= TIMESTAMP(DATE_TRUNC(CURRENT_DATE("Asia/Tokyo"), YEAR), "Asia/Tokyo")
+)"#,
+            self.query_project, self.dataset, self.table
+        )
+    }
+}
+
+fn parse_cost_summary(response: &QueryResponse) -> Result<CostSummary> {
+    let row = response
+        .rows
+        .first()
+        .context("billing query returned no rows")?;
+    anyhow::ensure!(row.f.len() == 4, "billing query returned invalid columns");
+    Ok(CostSummary {
+        monthly: parse_amount(&row.f[0])?,
+        yearly: parse_amount(&row.f[1])?,
+        currency: row.f[2].v.clone().unwrap_or_else(|| "不明".into()),
+        exported_at: row.f[3].v.clone(),
+    })
+}
+
+fn parse_amount(cell: &QueryCell) -> Result<f64> {
+    cell.v
+        .as_deref()
+        .unwrap_or("0")
+        .parse()
+        .context("billing query returned invalid cost")
+}
+
+fn valid_project_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.chars().all(|character| {
+            character.is_ascii_lowercase() || character.is_ascii_digit() || character == '-'
+        })
+}
+
+fn valid_bigquery_id(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || character == '_')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_identifiers_before_building_sql() {
+        assert!(BillingClient::new(
+            "billing-project".into(),
+            "billing_export".into(),
+            "gcp_billing_export_v1_ACCOUNT".into(),
+            "game-project".into(),
+            100_000_000,
+        )
+        .is_ok());
+        assert!(BillingClient::new(
+            "billing-project`".into(),
+            "billing_export".into(),
+            "table".into(),
+            "game-project".into(),
+            100_000_000,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn parses_cost_summary_row() {
+        let response: QueryResponse = serde_json::from_str(
+            r#"{"jobComplete":true,"rows":[{"f":[{"v":"123.4"},{"v":"567.8"},{"v":"JPY"},{"v":"2026-08-12T03:00:00Z"}]}]}"#,
+        )
+        .expect("response should parse");
+        assert_eq!(
+            parse_cost_summary(&response).expect("summary should parse"),
+            CostSummary {
+                monthly: 123.4,
+                yearly: 567.8,
+                currency: "JPY".into(),
+                exported_at: Some("2026-08-12T03:00:00Z".into()),
+            }
+        );
+    }
+
+    #[test]
+    fn query_filters_cost_project_and_current_year() {
+        let client = BillingClient::new(
+            "billing-project".into(),
+            "billing_export".into(),
+            "gcp_billing_export_v1_ACCOUNT".into(),
+            "game-project".into(),
+            100_000_000,
+        )
+        .expect("client should build");
+        let query = client.query();
+
+        assert!(query.contains("project.id = @cost_project"));
+        assert!(query.contains("DATE_TRUNC(CURRENT_DATE(\"Asia/Tokyo\"), YEAR)"));
+        assert!(query.contains("DATE_TRUNC(CURRENT_DATE(\"Asia/Tokyo\"), MONTH)"));
+        assert!(query.contains("SUM(credit.amount) FROM UNNEST(credits)"));
+    }
+}

--- a/src/usecase/seven_days_usecase.rs
+++ b/src/usecase/seven_days_usecase.rs
@@ -1,3 +1,4 @@
+use crate::services::seven_days_billing::{BillingClient, CostSummary};
 use crate::services::seven_days_gcp::{
     ComputeClient, DuckDnsClient, GuestRuntimeState, InstanceStatus,
 };
@@ -17,6 +18,7 @@ pub struct SevenDaysUsecase {
     domain: String,
     port: u16,
     auth: Authorization,
+    billing: Option<BillingClient>,
 }
 
 #[derive(Clone)]
@@ -65,6 +67,19 @@ impl SevenDaysUsecase {
         };
         let parse = |name: &str| -> Result<i64> { Ok(required(name)?.parse()?) };
         let (duckdns_subdomain, domain) = duckdns_names(&required("SEVEN_DAYS_DUCKDNS_DOMAIN")?)?;
+        let billing = optional_env("SEVEN_DAYS_BILLING_DATASET")
+            .map(|dataset| {
+                BillingClient::new(
+                    optional_env("SEVEN_DAYS_BILLING_PROJECT").unwrap_or_else(|| project.clone()),
+                    dataset,
+                    required("SEVEN_DAYS_BILLING_TABLE")?,
+                    project.clone(),
+                    optional_env("SEVEN_DAYS_BILLING_MAX_BYTES")
+                        .unwrap_or_else(|| "100000000".into())
+                        .parse()?,
+                )
+            })
+            .transpose()?;
         Ok(Some(Self {
             compute: ComputeClient::new(
                 project,
@@ -84,6 +99,7 @@ impl SevenDaysUsecase {
                 admin_users: id_set("SEVEN_DAYS_DISCORD_ADMIN_USER_IDS")?,
                 admin_roles: id_set("SEVEN_DAYS_DISCORD_ADMIN_ROLE_IDS")?,
             },
+            billing,
         }))
     }
 
@@ -147,7 +163,7 @@ impl SevenDaysUsecase {
     pub async fn stop(&self) -> Result<String> {
         let InstanceStatus { state, .. } = self.compute.status().await?;
         if state == "TERMINATED" {
-            return Ok("VM はすでに停止しているのだ。".into());
+            return Ok(self.with_costs("VM はすでに停止しているのだ。").await);
         }
         anyhow::ensure!(
             state == "RUNNING",
@@ -157,7 +173,9 @@ impl SevenDaysUsecase {
         let deadline = Instant::now() + STOP_TIMEOUT;
         while Instant::now() < deadline {
             if self.compute.status().await?.state == "TERMINATED" {
-                return Ok("ワールドを保存して VM を安全に停止したのだ。".into());
+                return Ok(self
+                    .with_costs("ワールドを保存して VM を安全に停止したのだ。")
+                    .await);
             }
             tokio::time::sleep(POLL_INTERVAL).await;
         }
@@ -169,6 +187,21 @@ impl SevenDaysUsecase {
             return Ok(false);
         };
         Ok(guest_runtime_is_current_and_ready(status, &runtime))
+    }
+
+    async fn with_costs(&self, message: &str) -> String {
+        let Some(billing) = &self.billing else {
+            return format!("{message}\n料金情報は設定されていないのだ。");
+        };
+        match billing.costs().await {
+            Ok(costs) => format!("{message}\n{}", format_costs(&costs)),
+            Err(error) => {
+                tracing::warn!(error = %error, "7DTD billing query failed after stop");
+                format!(
+                    "{message}\n料金情報は取得できなかったのだ。Billing export を確認してほしいのだ。"
+                )
+            }
+        }
     }
 }
 
@@ -231,6 +264,24 @@ fn guest_runtime_is_current_and_ready(
         return false;
     };
     runtime_started >= instance_started
+}
+
+fn format_costs(costs: &CostSummary) -> String {
+    let exported_at = costs
+        .exported_at
+        .as_deref()
+        .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+        .map(|value| {
+            value
+                .with_timezone(&chrono_tz::Asia::Tokyo)
+                .format("%Y-%m-%d %H:%M JST")
+                .to_string()
+        })
+        .unwrap_or_else(|| "不明".into());
+    format!(
+        "料金（反映済み概算）: 今月 {} {:.0} / 今年 {} {:.0}\n集計反映時点: {}\n※直近の利用分はまだ反映されていない場合があるのだ。",
+        costs.currency, costs.monthly, costs.currency, costs.yearly, exported_at
+    )
 }
 
 #[cfg(test)]
@@ -322,5 +373,18 @@ mod tests {
             ..current
         };
         assert!(!guest_runtime_is_current_and_ready(&status, &stale));
+    }
+
+    #[test]
+    fn formats_billing_costs_with_export_time() {
+        assert_eq!(
+            format_costs(&CostSummary {
+                monthly: 1234.4,
+                yearly: 5678.6,
+                currency: "JPY".into(),
+                exported_at: Some("2026-08-12T03:00:00Z".into()),
+            }),
+            "料金（反映済み概算）: 今月 JPY 1234 / 今年 JPY 5679\n集計反映時点: 2026-08-12 12:00 JST\n※直近の利用分はまだ反映されていない場合があるのだ。"
+        );
     }
 }

--- a/src/usecase/seven_days_usecase.rs
+++ b/src/usecase/seven_days_usecase.rs
@@ -7,7 +7,6 @@ use anyhow::{Context as _, Result};
 use chrono::{DateTime, Utc};
 use sqlx::PgPool;
 use std::{collections::HashSet, env, sync::Arc, time::Duration};
-use tokio::net::TcpStream;
 use tokio::time::Instant;
 
 const START_TIMEOUT: Duration = Duration::from_secs(10 * 60);


### PR DESCRIPTION
## 概要

- `/7dtd stop` 完了後に、7DTD用GCPプロジェクトの当月・当年の利用料金を表示
- Cloud Billing Standard usage cost exportをBigQueryで集計し、credits反映後のnet cost・通貨・集計反映時点を返す
- BigQuery datasetとCloud Run向け最小IAMをTerraformへ追加

Closes #45

> [!NOTE]
> 本PRはランタイム同期PR #46をベースにした積み上げPRです。

## 作業内容

- Metadata ServerのアクセストークンでBigQuery REST APIを呼ぶ料金集計clientを追加
- 東京時間の当月初・当年初で対象期間を絞り、`project.id`をnamed parameterで限定
- `cost + credits.amount`を集計し、query上限を既定100 MBに設定
- 停止済み確認後に料金を取得し、取得失敗時も停止成功メッセージを維持
- BigQuery API、billing export dataset、`roles/bigquery.jobUser`、dataset単位の`roles/bigquery.dataViewer`を追加
- README、Runbook、Terraform README、UMLを同期

## 作業意図

- 停止操作の直後に、運用者が反映済みの月次・年次コストをDiscord上で把握できるようにするため
- Billing exportの遅延を明示し、料金取得障害を安全停止処理から分離するため
- table名を設定値、project filterをquery parameterとして扱い、SQL組み立てと読み取り権限の範囲を限定するため

## 手動で次にするべき作業

- #46の後にTerraformをplan/applyし、出力された`billing_export_dataset`を確認する
- Cloud Billing ConsoleでStandard usage cost exportを有効化し、そのdatasetを保存先に指定する
- 自動作成された`gcp_billing_export_v1_...` table名を確認する
- Cloud Runへ`SEVEN_DAYS_BILLING_DATASET`と`SEVEN_DAYS_BILLING_TABLE`を設定する
- 必要に応じて`SEVEN_DAYS_BILLING_PROJECT`と`SEVEN_DAYS_BILLING_MAX_BYTES`を上書きする
- exportの初回反映後、検証環境で`/7dtd stop`の料金表示と停止成功の独立性を確認する

## 変更ファイル

- `src/services/seven_days_billing.rs`
- `src/services/mod.rs`
- `src/usecase/seven_days_usecase.rs`
- `infra/terraform/seven-days-server/main.tf`
- `infra/terraform/seven-days-server/variables.tf`
- `infra/terraform/seven-days-server/outputs.tf`
- `infra/terraform/seven-days-server/terraform.tfvars.example`
- `infra/terraform/seven-days-server/README.md`
- `README.md`
- `docs/seven-days-server.md`
- `docs/uml/seven-days-server.puml`

## テスト結果

- `cargo fmt --check`: 成功
- `cargo clippy --all-targets --all-features -- -D warnings`: 成功（macOS SDKのclangを明示）
- `cargo test`: 39件成功（macOS SDKのclangを明示）
- `terraform fmt -check main.tf variables.tf outputs.tf`: 成功
- 補足: 既定のNix側`cc`では環境依存の`ld: library not found for -liconv`が発生するが、macOS SDK付属clangでは全テスト成功

## 制限事項

- Cloud Billing Account側のexport有効化はTerraformでは行わず、Consoleでの手動設定が必要
- Billing exportには配信遅延があり、停止直前の利用分を含むリアルタイム料金は保証しない
- queryが10秒以内に完了しない場合や既定100 MB上限を超えた場合は料金取得不可と表示し、停止結果は成功のまま返す
- 新規API client、Terraform、運用文書を同時に追加するため推奨差分量を超えるが、変更はIssue #45の料金表示に限定
